### PR TITLE
DynamoDBテーブルの課金モードをプロビジョニング済みキャパシティに変更

### DIFF
--- a/terraform/modules/api/dynamodb.tf
+++ b/terraform/modules/api/dynamodb.tf
@@ -4,9 +4,11 @@
 
 # Events Table - stores Nostr events
 resource "aws_dynamodb_table" "events" {
-  name         = "nostr_relay_events"
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "id"
+  name             = "nostr_relay_events"
+  billing_mode     = "PROVISIONED"
+  read_capacity    = 21
+  write_capacity   = 21
+  hash_key         = "id"
 
   attribute {
     name = "id"
@@ -44,6 +46,8 @@ resource "aws_dynamodb_table" "events" {
     hash_key        = "pubkey"
     range_key       = "created_at"
     projection_type = "ALL"
+    read_capacity   = 1
+    write_capacity  = 1
   }
 
   # GSI-KindCreatedAt: For kinds filter queries
@@ -52,6 +56,8 @@ resource "aws_dynamodb_table" "events" {
     hash_key        = "kind"
     range_key       = "created_at"
     projection_type = "ALL"
+    read_capacity   = 1
+    write_capacity  = 1
   }
 
   # GSI-PkKind: For Replaceable event lookups (pubkey#kind)
@@ -60,6 +66,8 @@ resource "aws_dynamodb_table" "events" {
     hash_key        = "pk_kind"
     range_key       = "created_at"
     projection_type = "ALL"
+    read_capacity   = 1
+    write_capacity  = 1
   }
 
   # GSI-PkKindD: For Addressable event lookups (pubkey#kind#d_tag)
@@ -68,6 +76,8 @@ resource "aws_dynamodb_table" "events" {
     hash_key        = "pk_kind_d"
     range_key       = "created_at"
     projection_type = "ALL"
+    read_capacity   = 1
+    write_capacity  = 1
   }
 
   tags = {


### PR DESCRIPTION
## 概要
DynamoDBテーブルの課金モードを従量課金制（PAY_PER_REQUEST）からプロビジョニング済みキャパシティ（PROVISIONED）に変更しました。

## 変更内容
- **課金モード**: `PAY_PER_REQUEST` → `PROVISIONED`
- **メインテーブル**:
  - 読み取りキャパシティ: 21
  - 書き込みキャパシティ: 21
- **各GSI** (GSI-PubkeyCreatedAt, GSI-KindCreatedAt, GSI-PkKind, GSI-PkKindD):
  - 読み取りキャパシティ: 1
  - 書き込みキャパシティ: 1

## 影響
- コスト構造が変わります（トラフィックパターンに応じて最適化可能）
- 予測可能な料金体系になります
- キャパシティ設定により、スループットの上限が設定されます

## テスト計画
- [ ] Terraformの`plan`を実行して変更内容を確認
- [ ] 適用後、DynamoDBテーブルの動作を確認
- [ ] キャパシティメトリクスを監視

🤖 Generated with [Claude Code](https://claude.com/claude-code)