### PR TITLE
CloudFrontに地理的制限を追加（中国・ロシア・北朝鮮をブロック）

### DIFF
--- a/terraform/modules/api/cloudfront.tf
+++ b/terraform/modules/api/cloudfront.tf
@@ -89,7 +89,8 @@ resource "aws_cloudfront_distribution" "relay" {
   # --------------------------------------
   restrictions {
     geo_restriction {
-      restriction_type = "none"
+      restriction_type = "blacklist"
+      locations        = ["CN", "RU", "KP"]
     }
   }
 


### PR DESCRIPTION
## 概要
CloudFrontディストリビューションにブラックリスト方式の地理的制限を追加し、リスクの高い国からのアクセスを拒否します。

## 変更内容
- `terraform/modules/api/cloudfront.tf` の `restrictions` ブロックを変更
- `restriction_type` を `none` から `blacklist` に変更
- 拒否対象国: CN（中国）、RU（ロシア）、KP（北朝鮮）

## テスト計画
- [x] `terraform fmt` でフォーマット確認
- [x] `terraform validate` で構文確認
- [x] `terraform plan` で変更内容確認
- [ ] `terraform apply` でデプロイ

## 備考
- ブロックされたユーザーにはHTTP 403エラーが返却されます
- CloudFrontエッジロケーションのIP地理情報に基づいて判定されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)