### PR TITLE
CloudFront設定を日本国内向けに最適化

### DIFF
--- a/terraform/modules/api/cloudfront.tf
+++ b/terraform/modules/api/cloudfront.tf
@@ -17,6 +17,7 @@ resource "aws_cloudfront_distribution" "relay" {
   is_ipv6_enabled = true
   comment         = "Nostr Relay CloudFront Distribution"
   aliases         = ["relay.${var.domain_name}"]
+  price_class     = "PriceClass_200"
 
   # --------------------------------------
   # デフォルトオリジン: WebSocket API Gateway
@@ -89,8 +90,8 @@ resource "aws_cloudfront_distribution" "relay" {
   # --------------------------------------
   restrictions {
     geo_restriction {
-      restriction_type = "blacklist"
-      locations        = ["CN", "RU", "KP"]
+      restriction_type = "whitelist"
+      locations        = ["JP"]
     }
   }
 


### PR DESCRIPTION
## Summary
- GEO restrictionをブラックリスト方式からホワイトリスト方式に変更し、日本(JP)のみアクセス許可
- PriceClassを`PriceClass_All`から`PriceClass_200`に変更し、エッジロケーションを最適化

## 変更内容
| 設定 | 変更前 | 変更後 |
|------|--------|--------|
| GEO restriction | blacklist (CN, RU, KP を拒否) | whitelist (JP のみ許可) |
| PriceClass | PriceClass_All (全世界) | PriceClass_200 (日本含む最小) |

## Test plan
- [x] `terraform plan` で変更内容を確認
- [x] `terraform apply` で適用完了
- [x] NIP-11 リレー情報取得テスト
- [x] WebSocket接続テスト
- [x] イベント投稿テスト
- [x] イベント取得テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)