### PR TITLE
feat: カスタム絵文字リアクション送信機能

### DIFF
--- a/apps/web/app/components/ActionBar.tsx
+++ b/apps/web/app/components/ActionBar.tsx
@@ -3,6 +3,8 @@
 import { useState, useRef } from "react";
 import { MessageSquare, Repeat2, Plus, Smile, Quote } from "lucide-react";
 import { EmojiPickerPopover } from "./EmojiPickerPopover";
+import type { CustomEmoji, EmojiSet } from "../hooks/useCustomEmojis";
+import type { RecentEmoji } from "../hooks/useRecentEmojis";
 
 /** NoteCard用アクションバー（カードクリックで展開するリアクション操作UI） */
 
@@ -22,11 +24,15 @@ interface ActionBarProps {
   /** 自分が既にリポスト済みかどうか */
   isAlreadyReposted: boolean;
   /** 絵文字ピッカーから絵文字が選択されたときのハンドラ */
-  onEmojiSelect?: (emoji: string) => void;
+  onEmojiSelect?: (emoji: string, imageUrl?: string) => void;
   /** 絵文字ピッカーの開閉状態が変わったときのコールバック */
   onPickerOpenChange?: (isOpen: boolean) => void;
   /** 最近使った絵文字の配列 */
-  recentEmojis?: string[];
+  recentEmojis?: RecentEmoji[];
+  /** カスタム絵文字セット */
+  emojiSets?: EmojiSet[];
+  /** 個別のカスタム絵文字 */
+  looseEmojis?: CustomEmoji[];
 }
 
 export function ActionBar({
@@ -40,6 +46,8 @@ export function ActionBar({
   onEmojiSelect,
   onPickerOpenChange,
   recentEmojis,
+  emojiSets,
+  looseEmojis,
 }: ActionBarProps) {
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const emojiButtonRef = useRef<HTMLButtonElement>(null);
@@ -149,11 +157,13 @@ export function ActionBar({
             <EmojiPickerPopover
               isOpen={isPickerOpen}
               onClose={() => updatePickerOpen(false)}
-              onEmojiSelect={(emoji) => {
-                onEmojiSelect(emoji);
+              onEmojiSelect={(emoji, imageUrl) => {
+                onEmojiSelect(emoji, imageUrl);
               }}
               anchorRef={emojiButtonRef}
               recentEmojis={recentEmojis}
+              emojiSets={emojiSets}
+              looseEmojis={looseEmojis}
             />
           </>
         )}

--- a/apps/web/app/components/EmojiPickerPopover.tsx
+++ b/apps/web/app/components/EmojiPickerPopover.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useRef, useEffect, useState, useCallback } from "react";
+import { useRef, useEffect, useState, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { EmojiPicker } from "frimousse";
+import type { CustomEmoji, EmojiSet } from "../hooks/useCustomEmojis";
+import type { RecentEmoji } from "../hooks/useRecentEmojis";
+
+/** タブの種類 */
+type TabType = "recent" | "custom" | "unicode";
 
 interface EmojiPickerPopoverProps {
   /** ポップオーバーの開閉状態 */
@@ -10,25 +15,237 @@ interface EmojiPickerPopoverProps {
   /** ポップオーバーを閉じるハンドラ */
   onClose: () => void;
   /** 絵文字が選択されたときのハンドラ */
-  onEmojiSelect: (emoji: string) => void;
+  onEmojiSelect: (emoji: string, imageUrl?: string) => void;
   /** ピッカーのアンカー要素（位置計算用） */
   anchorRef: React.RefObject<HTMLElement | null>;
   /** 最近使った絵文字の配列 */
-  recentEmojis?: string[];
+  recentEmojis?: RecentEmoji[];
+  /** カスタム絵文字セット */
+  emojiSets?: EmojiSet[];
+  /** セットに属さないカスタム絵文字 */
+  looseEmojis?: CustomEmoji[];
 }
 
-/** 絵文字ピッカーの内部コンテンツ（isOpen時のみマウントされ、閉じるとアンマウント→stateリセット） */
-function EmojiPickerContent({
-  onClose,
+/** カスタム絵文字ボタン */
+function CustomEmojiButton({
+  shortcode,
+  url,
   onEmojiSelect,
-  recentEmojis,
+  onClose,
 }: {
+  shortcode: string;
+  url: string;
+  onEmojiSelect: (emoji: string, imageUrl?: string) => void;
   onClose: () => void;
-  onEmojiSelect: (emoji: string) => void;
-  recentEmojis?: string[];
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        onEmojiSelect(`:${shortcode}:`, url);
+        onClose();
+      }}
+      title={`:${shortcode}:`}
+      className="flex items-center justify-center w-8 h-8 rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+    >
+      <img
+        src={url}
+        alt={`:${shortcode}:`}
+        className="w-5 h-5 object-contain"
+        referrerPolicy="no-referrer"
+      />
+    </button>
+  );
+}
+
+/** タブバー */
+function TabBar({
+  activeTab,
+  onTabChange,
+  hasCustom,
+}: {
+  activeTab: TabType;
+  onTabChange: (tab: TabType) => void;
+  hasCustom: boolean;
+}) {
+  const tabs: { type: TabType; icon: string; label: string }[] = [
+    { type: "recent", icon: "🕐", label: "最近使った絵文字" },
+    ...(hasCustom
+      ? [{ type: "custom" as const, icon: "⭐", label: "カスタム絵文字" }]
+      : []),
+    { type: "unicode", icon: "😀", label: "Unicode絵文字" },
+  ];
+
+  return (
+    <div className="flex border-b border-gray-200 dark:border-gray-700">
+      {tabs.map((tab) => (
+        <button
+          key={tab.type}
+          type="button"
+          aria-label={tab.label}
+          onClick={() => onTabChange(tab.type)}
+          className={`flex-1 py-1 text-center text-sm cursor-pointer transition-colors ${
+            activeTab === tab.type
+              ? "border-b-2 border-blue-500 dark:border-blue-400"
+              : "text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
+          }`}
+        >
+          {tab.icon}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** 最近使った絵文字タブの中身 */
+function RecentTab({
+  recentEmojis,
+  onEmojiSelect,
+  onClose,
+}: {
+  recentEmojis: RecentEmoji[];
+  onEmojiSelect: (emoji: string, imageUrl?: string) => void;
+  onClose: () => void;
+}) {
+  if (recentEmojis.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-sm text-gray-400 dark:text-gray-500">
+        まだリアクションしていません
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="px-3 py-1.5 text-xs font-semibold text-gray-500 dark:text-gray-400 sticky top-0 bg-white dark:bg-gray-800">
+        最近使った絵文字
+      </div>
+      <div className="flex flex-wrap px-1">
+      {recentEmojis.map((recent) =>
+        recent.imageUrl ? (
+          <CustomEmojiButton
+            key={recent.emoji}
+            shortcode={recent.emoji.slice(1, -1)}
+            url={recent.imageUrl}
+            onEmojiSelect={onEmojiSelect}
+            onClose={onClose}
+          />
+        ) : (
+          <button
+            key={recent.emoji}
+            type="button"
+            onClick={() => {
+              onEmojiSelect(recent.emoji);
+              onClose();
+            }}
+            className="flex items-center justify-center w-8 h-8 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-xl cursor-pointer"
+          >
+            {recent.emoji}
+          </button>
+        ),
+      )}
+      </div>
+    </div>
+  );
+}
+
+/** カスタム絵文字タブの中身 */
+function CustomTab({
+  emojiSets,
+  looseEmojis,
+  search,
+  onEmojiSelect,
+  onClose,
+}: {
+  emojiSets: EmojiSet[];
+  looseEmojis: CustomEmoji[];
+  search: string;
+  onEmojiSelect: (emoji: string, imageUrl?: string) => void;
+  onClose: () => void;
+}) {
+  const filteredSets = useMemo(() => {
+    if (search === "") return emojiSets;
+    const query = search.toLowerCase();
+    return emojiSets
+      .map((set) => ({
+        ...set,
+        emojis: set.emojis.filter((e) =>
+          e.shortcode.toLowerCase().includes(query),
+        ),
+      }))
+      .filter((set) => set.emojis.length > 0);
+  }, [emojiSets, search]);
+
+  const filteredLoose = useMemo(() => {
+    if (search === "") return looseEmojis;
+    const query = search.toLowerCase();
+    return looseEmojis.filter((e) =>
+      e.shortcode.toLowerCase().includes(query),
+    );
+  }, [looseEmojis, search]);
+
+  if (filteredSets.length === 0 && filteredLoose.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-sm text-gray-400 dark:text-gray-500">
+        見つかりません
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-1">
+      {filteredSets.map(
+        (set) =>
+          set.emojis.length > 0 && (
+            <div key={set.id}>
+              <div className="px-3 py-1.5 text-xs font-semibold text-gray-500 dark:text-gray-400 sticky top-0 bg-white dark:bg-gray-800">
+                {set.icon ? `${set.icon} ${set.name}` : set.name}
+              </div>
+              <div className="flex flex-wrap px-1">
+                {set.emojis.map((e) => (
+                  <CustomEmojiButton
+                    key={e.shortcode}
+                    shortcode={e.shortcode}
+                    url={e.url}
+                    onEmojiSelect={onEmojiSelect}
+                    onClose={onClose}
+                  />
+                ))}
+              </div>
+            </div>
+          ),
+      )}
+      {filteredLoose.length > 0 && (
+        <div>
+          <div className="px-3 py-1.5 text-xs font-semibold text-gray-500 dark:text-gray-400 sticky top-0 bg-white dark:bg-gray-800">
+            マイ絵文字
+          </div>
+          <div className="flex flex-wrap px-1">
+            {filteredLoose.map((e) => (
+              <CustomEmojiButton
+                key={e.shortcode}
+                shortcode={e.shortcode}
+                url={e.url}
+                onEmojiSelect={onEmojiSelect}
+                onClose={onClose}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Unicode絵文字タブの中身（frimousse） */
+function UnicodeTab({
+  onEmojiSelect,
+  onClose,
+}: {
+  onEmojiSelect: (emoji: string, imageUrl?: string) => void;
+  onClose: () => void;
 }) {
   const searchRef = useRef<HTMLInputElement>(null);
-  const [search, setSearch] = useState("");
 
   // 検索ボックスに自動フォーカス
   useEffect(() => {
@@ -47,36 +264,16 @@ function EmojiPickerContent({
     >
       <EmojiPicker.Search
         ref={searchRef}
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
         placeholder="絵文字を検索..."
         className="w-full px-3 py-2 text-sm border-b border-gray-200 dark:border-gray-700 bg-transparent outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
       />
-      <EmojiPicker.Viewport className="h-[280px]">
-        <EmojiPicker.Loading className="flex items-center justify-center h-full text-sm text-gray-400 dark:text-gray-500">読み込み中...</EmojiPicker.Loading>
-        <EmojiPicker.Empty className="flex items-center justify-center h-full text-sm text-gray-400 dark:text-gray-500">見つかりません</EmojiPicker.Empty>
-        {recentEmojis && recentEmojis.length > 0 && search === "" && (
-          <div>
-            <div className="px-3 py-1.5 text-xs font-semibold text-gray-500 dark:text-gray-400 sticky top-0 bg-white dark:bg-gray-800">
-              最近使った絵文字
-            </div>
-            <div className="flex px-1">
-              {recentEmojis.map((emoji) => (
-                <button
-                  key={emoji}
-                  type="button"
-                  onClick={() => {
-                    onEmojiSelect(emoji);
-                    onClose();
-                  }}
-                  className="flex items-center justify-center w-8 h-8 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-xl cursor-pointer"
-                >
-                  {emoji}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
+      <EmojiPicker.Viewport className="h-[243px]">
+        <EmojiPicker.Loading className="flex items-center justify-center h-full text-sm text-gray-400 dark:text-gray-500">
+          読み込み中...
+        </EmojiPicker.Loading>
+        <EmojiPicker.Empty className="flex items-center justify-center h-full text-sm text-gray-400 dark:text-gray-500">
+          見つかりません
+        </EmojiPicker.Empty>
         <EmojiPicker.List
           components={{
             CategoryHeader: ({ category, ...props }) => (
@@ -108,6 +305,95 @@ function EmojiPickerContent({
   );
 }
 
+/** 絵文字ピッカーの内部コンテンツ（isOpen時のみマウントされ、閉じるとアンマウント→stateリセット） */
+function EmojiPickerContent({
+  onClose,
+  onEmojiSelect,
+  recentEmojis,
+  emojiSets,
+  looseEmojis,
+}: {
+  onClose: () => void;
+  onEmojiSelect: (emoji: string, imageUrl?: string) => void;
+  recentEmojis?: RecentEmoji[];
+  emojiSets?: EmojiSet[];
+  looseEmojis?: CustomEmoji[];
+}) {
+  const [activeTab, setActiveTab] = useState<TabType>("recent");
+  const [search, setSearch] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const hasCustom =
+    (emojiSets !== undefined && emojiSets.some((s) => s.emojis.length > 0)) ||
+    (looseEmojis !== undefined && looseEmojis.length > 0);
+
+  // タブ切替時に検索をリセット
+  const handleTabChange = useCallback((tab: TabType) => {
+    setActiveTab(tab);
+    setSearch("");
+  }, []);
+
+  // カスタムタブで検索ボックスに自動フォーカス
+  useEffect(() => {
+    if (activeTab === "custom") {
+      requestAnimationFrame(() => {
+        searchRef.current?.focus();
+      });
+    }
+  }, [activeTab]);
+
+  return (
+    <div>
+      <TabBar
+        activeTab={activeTab}
+        onTabChange={handleTabChange}
+        hasCustom={hasCustom}
+      />
+
+      {/* タブの中身 */}
+      <div style={{ height: 280 }}>
+        {activeTab === "recent" && (
+          <div className="overflow-y-auto h-full">
+            <RecentTab
+              recentEmojis={recentEmojis ?? []}
+              onEmojiSelect={onEmojiSelect}
+              onClose={onClose}
+            />
+          </div>
+        )}
+        {activeTab === "custom" && (
+          <div className="flex flex-col h-full">
+            <input
+              ref={searchRef}
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="カスタム絵文字を検索..."
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              className="w-full px-3 py-2 text-sm border-b border-gray-200 dark:border-gray-700 bg-transparent outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 flex-shrink-0"
+            />
+            <div className="flex-1 overflow-y-auto">
+              <CustomTab
+                emojiSets={emojiSets ?? []}
+                looseEmojis={looseEmojis ?? []}
+                search={search}
+                onEmojiSelect={onEmojiSelect}
+                onClose={onClose}
+              />
+            </div>
+          </div>
+        )}
+        {activeTab === "unicode" && (
+          <UnicodeTab onEmojiSelect={onEmojiSelect} onClose={onClose} />
+        )}
+      </div>
+    </div>
+  );
+}
+
 /** 絵文字ピッカーポップオーバーコンポーネント（Portal描画） */
 export function EmojiPickerPopover({
   isOpen,
@@ -115,26 +401,30 @@ export function EmojiPickerPopover({
   onEmojiSelect,
   anchorRef,
   recentEmojis,
+  emojiSets,
+  looseEmojis,
 }: EmojiPickerPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
-  const [position, setPosition] = useState<{ top: number; left: number; placement: "above" | "below" }>({ top: 0, left: 0, placement: "above" });
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+    placement: "above" | "below";
+  }>({ top: 0, left: 0, placement: "above" });
 
   /** アンカー要素の位置からポップオーバーの位置を計算する（上下自動切り替え） */
   const updatePosition = useCallback(() => {
     if (!anchorRef.current) return;
     const rect = anchorRef.current.getBoundingClientRect();
     const pickerWidth = Math.min(320, window.innerWidth * 0.9);
-    const pickerHeight = 320; // maxHeight と同じ
-    const gap = 8; // アンカーとの間隔
+    const pickerHeight = 360; // タブバー分を加算
+    const gap = 8;
 
-    // 左端の調整
     let left = rect.left;
     if (left + pickerWidth > window.innerWidth - 8) {
       left = window.innerWidth - pickerWidth - 8;
     }
     if (left < 8) left = 8;
 
-    // 上に十分なスペースがあれば上に、なければ下に表示
     const spaceAbove = rect.top;
     const placement = spaceAbove >= pickerHeight + gap ? "above" : "below";
 
@@ -168,12 +458,10 @@ export function EmojiPickerPopover({
       }
     };
 
-    // Escapeキーで閉じる
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
 
-    // スクロール・リサイズ時に位置を更新
     const handleScroll = () => updatePosition();
 
     document.addEventListener("mousedown", handleMouseDown);
@@ -197,10 +485,10 @@ export function EmojiPickerPopover({
       data-emoji-picker-popover
       style={{
         width: "min(320px, 90vw)",
-        maxHeight: "320px",
         top: position.top,
         left: position.left,
-        transform: position.placement === "above" ? "translateY(-100%)" : undefined,
+        transform:
+          position.placement === "above" ? "translateY(-100%)" : undefined,
         zIndex: 9999,
       }}
       onClick={(e) => e.stopPropagation()}
@@ -209,6 +497,8 @@ export function EmojiPickerPopover({
         onClose={onClose}
         onEmojiSelect={onEmojiSelect}
         recentEmojis={recentEmojis}
+        emojiSets={emojiSets}
+        looseEmojis={looseEmojis}
       />
     </div>,
     document.body,

--- a/apps/web/app/components/LiveCanvas.tsx
+++ b/apps/web/app/components/LiveCanvas.tsx
@@ -27,6 +27,8 @@ import { CanvasHeader } from "./CanvasHeader";
 import { EmptyState } from "./EmptyState";
 import type { NostrEvent } from "../types/nostr";
 import type { EventCache } from "../hooks/useEventCache";
+import type { CustomEmoji, EmojiSet } from "../hooks/useCustomEmojis";
+import type { RecentEmoji } from "../hooks/useRecentEmojis";
 
 interface LiveCanvasProps {
   notes: NoteCardType[];
@@ -47,14 +49,16 @@ interface LiveCanvasProps {
   cache: EventCache;
   onLogout: () => void;
   isProcessing: boolean;
-  recentEmojis: string[];
+  recentEmojis: RecentEmoji[];
+  emojiSets: EmojiSet[];
+  looseEmojis: CustomEmoji[];
 }
 
 function calcColumnCount(width: number): number {
   return Math.max(1, Math.floor(width / COLUMN_WIDTH));
 }
 
-export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis }: LiveCanvasProps) {
+export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis, emojiSets, looseEmojis }: LiveCanvasProps) {
   const [columnCount, setColumnCount] = useState(1);
   const [holdSet, setHoldSet] = useState<Set<string>>(() => new Set());
 
@@ -493,6 +497,8 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
                               reactions={reactions}
                               myPubkey={pubkey}
                               recentEmojis={recentEmojis}
+                              emojiSets={emojiSets}
+                              looseEmojis={looseEmojis}
                               onReaction={(targetEventId, targetPubkey, emoji, imageUrl) => {
                                 sendReaction(targetEventId, targetPubkey, emoji, imageUrl).catch(console.error);
                               }}
@@ -519,6 +525,8 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
                               note={note}
                               profile={profiles.get(note.pubkey)}
                               recentEmojis={recentEmojis}
+                              emojiSets={emojiSets}
+                              looseEmojis={looseEmojis}
                               reposterProfile={note.repostInfo ? profiles.get(note.repostInfo.reposterPubkey) : undefined}
                               reactions={reactions.get(note.eventId)}
                               myPubkey={pubkey}

--- a/apps/web/app/components/NoteCard.tsx
+++ b/apps/web/app/components/NoteCard.tsx
@@ -9,6 +9,8 @@ import { ActionBar } from "./ActionBar";
 import { ReplyCompose } from "./ReplyCompose";
 import { ReactionTooltip } from "./ReactionTooltip";
 import type { EventCache } from "../hooks/useEventCache";
+import type { CustomEmoji, EmojiSet } from "../hooks/useCustomEmojis";
+import type { RecentEmoji } from "../hooks/useRecentEmojis";
 
 /** npubの省略表示を生成 */
 function shortenPubkey(pubkey: string): string {
@@ -68,10 +70,14 @@ interface NoteCardProps {
   /** 引用ボタンクリック時のコールバック */
   onQuote?: () => void;
   /** 最近使った絵文字の配列 */
-  recentEmojis?: string[];
+  recentEmojis?: RecentEmoji[];
+  /** カスタム絵文字セット */
+  emojiSets?: EmojiSet[];
+  /** 個別のカスタム絵文字 */
+  looseEmojis?: CustomEmoji[];
 }
 
-export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, onReaction, onRepost, cache, profiles, onHeightChange, onHold, onRelease, onReplyPublish, publishEvent, myProfile, onQuote, recentEmojis }: NoteCardProps) {
+export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, onReaction, onRepost, cache, profiles, onHeightChange, onHold, onRelease, onReplyPublish, publishEvent, myProfile, onQuote, recentEmojis, emojiSets, looseEmojis }: NoteCardProps) {
   const displayName =
     profile?.display_name || profile?.name || shortenPubkey(note.pubkey);
 
@@ -416,13 +422,15 @@ export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, 
           onQuote();
         } : undefined}
         recentEmojis={recentEmojis}
+        emojiSets={emojiSets}
+        looseEmojis={looseEmojis}
         onPickerOpenChange={(open) => {
           isEmojiPickerOpenRef.current = open;
         }}
-        onEmojiSelect={async (emoji) => {
+        onEmojiSelect={async (emoji, imageUrl) => {
           try {
             if (onReaction) {
-              await onReaction(emoji);
+              await onReaction(emoji, imageUrl);
             }
           } catch (e) {
             console.error(e);

--- a/apps/web/app/components/ThreadCard.tsx
+++ b/apps/web/app/components/ThreadCard.tsx
@@ -14,6 +14,8 @@ import type { EventCache } from "../hooks/useEventCache";
 import { ActionBar } from "./ActionBar";
 import { ReplyCompose } from "./ReplyCompose";
 import { ReactionTooltip } from "./ReactionTooltip";
+import type { CustomEmoji, EmojiSet } from "../hooks/useCustomEmojis";
+import type { RecentEmoji } from "../hooks/useRecentEmojis";
 
 /** npubの省略表示を生成 */
 function shortenPubkey(pubkey: string): string {
@@ -82,7 +84,11 @@ interface ThreadCardProps {
   /** 引用ボタン押下時のハンドラ */
   onQuote?: (eventId: string, pubkey: string) => void;
   /** 最近使った絵文字の配列 */
-  recentEmojis?: string[];
+  recentEmojis?: RecentEmoji[];
+  /** カスタム絵文字セット */
+  emojiSets?: EmojiSet[];
+  /** 個別のカスタム絵文字 */
+  looseEmojis?: CustomEmoji[];
 }
 
 export function ThreadCard({
@@ -100,6 +106,8 @@ export function ThreadCard({
   myProfile,
   onQuote,
   recentEmojis,
+  emojiSets,
+  looseEmojis,
 }: ThreadCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
@@ -269,6 +277,8 @@ export function ThreadCard({
             onQuote={onQuote ? () => onQuote(note.eventId, note.pubkey) : undefined}
             cache={cache}
             recentEmojis={recentEmojis}
+            emojiSets={emojiSets}
+            looseEmojis={looseEmojis}
           />
         );
       })}
@@ -338,7 +348,11 @@ interface ThreadNoteItemProps {
   onQuote?: () => void;
   cache?: EventCache;
   /** 最近使った絵文字の配列 */
-  recentEmojis?: string[];
+  recentEmojis?: RecentEmoji[];
+  /** カスタム絵文字セット */
+  emojiSets?: EmojiSet[];
+  /** 個別のカスタム絵文字 */
+  looseEmojis?: CustomEmoji[];
 }
 
 function ThreadNoteItem({
@@ -359,6 +373,8 @@ function ThreadNoteItem({
   onQuote,
   cache,
   recentEmojis,
+  emojiSets,
+  looseEmojis,
 }: ThreadNoteItemProps) {
   const profile = profiles.get(note.pubkey);
   const displayName =
@@ -605,11 +621,13 @@ function ThreadNoteItem({
           }}
           isAlreadyReposted={false}
           recentEmojis={recentEmojis}
+          emojiSets={emojiSets}
+          looseEmojis={looseEmojis}
           onPickerOpenChange={onPickerOpenChange}
-          onEmojiSelect={async (emoji) => {
+          onEmojiSelect={async (emoji, imageUrl) => {
             try {
               if (onReaction) {
-                await onReaction(note.eventId, note.pubkey, emoji);
+                await onReaction(note.eventId, note.pubkey, emoji, imageUrl);
               }
             } catch (e) {
               console.error(e);

--- a/apps/web/app/hooks/useCustomEmojis.ts
+++ b/apps/web/app/hooks/useCustomEmojis.ts
@@ -1,0 +1,180 @@
+import { useEffect, useState } from "react";
+import type { SimplePool } from "nostr-tools/pool";
+import type { Event } from "nostr-tools/core";
+import type { Filter } from "nostr-tools/filter";
+import type { SubCloser } from "nostr-tools/abstract-pool";
+
+export interface CustomEmoji {
+  shortcode: string;
+  url: string;
+}
+
+export interface EmojiSet {
+  id: string; // kind 30030 の d タグ
+  name: string; // title タグ > d タグ
+  icon?: string; // image タグ
+  emojis: CustomEmoji[];
+}
+
+export interface UseCustomEmojisResult {
+  emojiSets: EmojiSet[];
+  looseEmojis: CustomEmoji[];
+}
+
+const EMPTY_EMOJI_SETS: EmojiSet[] = [];
+const EMPTY_LOOSE_EMOJIS: CustomEmoji[] = [];
+
+/**
+ * ログインユーザーのカスタム絵文字パレット（NIP-51 kind 10030）を購読し、
+ * 参照されている絵文字セット（kind 30030）を解決するhook
+ *
+ * - kind 10030 の emoji タグ → looseEmojis
+ * - kind 10030 の a タグ (30030:<pubkey>:<d-tag>) → 各 kind 30030 を購読 → emojiSets
+ * - oneose後にサブスクリプションを閉じる
+ */
+export function useCustomEmojis(
+  pool: SimplePool | null,
+  relayUrls: string[],
+  pubkey: string | null,
+): UseCustomEmojisResult {
+  const [emojiSets, setEmojiSets] = useState<EmojiSet[]>(EMPTY_EMOJI_SETS);
+  const [looseEmojis, setLooseEmojis] = useState<CustomEmoji[]>(
+    EMPTY_LOOSE_EMOJIS,
+  );
+
+  useEffect(() => {
+    if (!pool || relayUrls.length === 0 || !pubkey) return;
+
+    let cancelled = false;
+    let paletteSub: SubCloser | null = null;
+    let setsSub: SubCloser | null = null;
+
+    paletteSub = pool.subscribeMany(
+      relayUrls,
+      { kinds: [10030], authors: [pubkey] },
+      {
+        onevent(event: Event) {
+          if (cancelled) return;
+
+          // emoji タグを収集
+          const loose: CustomEmoji[] = [];
+          // a タグから 30030 の参照を収集
+          const setRefs: { pubkey: string; dTag: string }[] = [];
+
+          for (const tag of event.tags) {
+            if (
+              tag[0] === "emoji" &&
+              tag.length >= 3 &&
+              tag[1] &&
+              tag[2]
+            ) {
+              loose.push({ shortcode: tag[1], url: tag[2] });
+            } else if (tag[0] === "a" && tag[1]) {
+              const parts = tag[1].split(":");
+              if (parts.length >= 3 && parts[0] === "30030") {
+                setRefs.push({ pubkey: parts[1], dTag: parts[2] });
+              }
+            }
+          }
+
+          if (!cancelled) {
+            setLooseEmojis(loose.length > 0 ? loose : EMPTY_LOOSE_EMOJIS);
+          }
+
+          // 絵文字セットの購読
+          if (setRefs.length === 0 || cancelled) return;
+
+          const resolvedSets: Map<string, EmojiSet> = new Map();
+
+          // 全セット参照をまとめたフィルタを作成
+          const allAuthors = [...new Set(setRefs.map((ref) => ref.pubkey))];
+          const allDTags = [...new Set(setRefs.map((ref) => ref.dTag))];
+          // 有効な参照の組み合わせを追跡（過剰取得をフィルタするため）
+          const validRefs = new Set(setRefs.map((ref) => `${ref.pubkey}:${ref.dTag}`));
+
+          setsSub = pool.subscribeMany(relayUrls, {
+            kinds: [30030],
+            authors: allAuthors,
+            "#d": allDTags,
+          }, {
+            onevent(setEvent: Event) {
+              if (cancelled) return;
+
+              const dTag =
+                setEvent.tags.find((t) => t[0] === "d")?.[1] ?? "";
+              const titleTag = setEvent.tags.find(
+                (t) => t[0] === "title",
+              )?.[1];
+              const imageTag = setEvent.tags.find(
+                (t) => t[0] === "image",
+              )?.[1];
+
+              const emojis: CustomEmoji[] = [];
+              for (const tag of setEvent.tags) {
+                if (
+                  tag[0] === "emoji" &&
+                  tag.length >= 3 &&
+                  tag[1] &&
+                  tag[2]
+                ) {
+                  emojis.push({ shortcode: tag[1], url: tag[2] });
+                }
+              }
+
+              const emojiSet: EmojiSet = {
+                id: dTag,
+                name: titleTag || dTag,
+                icon: imageTag,
+                emojis,
+              };
+
+              resolvedSets.set(dTag, emojiSet);
+            },
+            oneose() {
+              if (cancelled) return;
+
+              const sets = Array.from(resolvedSets.values());
+              setEmojiSets(sets.length > 0 ? sets : EMPTY_EMOJI_SETS);
+
+              if (setsSub) {
+                setsSub.close();
+                setsSub = null;
+              }
+            },
+          });
+        },
+        oneose() {
+          if (cancelled) return;
+
+          // palette サブスクリプションを閉じる
+          if (paletteSub) {
+            paletteSub.close();
+            paletteSub = null;
+          }
+        },
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      if (paletteSub) {
+        try {
+          paletteSub.close();
+        } catch {
+          // 既に閉じている場合は無視
+        }
+        paletteSub = null;
+      }
+      if (setsSub) {
+        try {
+          setsSub.close();
+        } catch {
+          // 既に閉じている場合は無視
+        }
+        setsSub = null;
+      }
+    };
+  }, [pool, relayUrls, pubkey]);
+
+  return { emojiSets, looseEmojis };
+}

--- a/apps/web/app/hooks/useNostrRelay.ts
+++ b/apps/web/app/hooks/useNostrRelay.ts
@@ -9,6 +9,8 @@ import { useNostrNotes } from "./useNostrNotes";
 import { useNostrReactions } from "./useNostrReactions";
 import { useEventCache } from "./useEventCache";
 import type { EventCache } from "./useEventCache";
+import { useCustomEmojis } from "./useCustomEmojis";
+import type { CustomEmoji, EmojiSet } from "./useCustomEmojis";
 import { SimplePool } from "nostr-tools/pool";
 import { CLIENT_TAG } from "../lib/constants";
 
@@ -23,6 +25,8 @@ interface UseNostrRelayResult {
   relayUrls: string[];
   pool: SimplePool | null;
   cache: EventCache;
+  emojiSets: EmojiSet[];
+  looseEmojis: CustomEmoji[];
   publishEvent: (event: NostrEvent) => Promise<void>;
   sendReaction: (targetEventId: string, targetPubkey: string, emoji: string, imageUrl?: string) => Promise<void>;
   sendRepost: (targetEventId: string, targetPubkey: string, originalEvent: NostrEvent) => Promise<void>;
@@ -43,6 +47,7 @@ export function useNostrRelay(
   const { pool, relayUrls, followPubkeys, status, setStatus } = useNostrConnection(pubkey);
   const { profiles, upsertProfile, fetchProfiles, profilesRef } = useNostrProfiles(pool, relayUrls, followPubkeys);
   const cache = useEventCache(pool, relayUrls, fetchProfiles);
+  const { emojiSets, looseEmojis } = useCustomEmojis(pool, relayUrls, pubkey);
 
   // initialEventIds を管理するstate
   const [initialEventIds, setInitialEventIds] = useState<string[]>([]);
@@ -151,5 +156,5 @@ export function useNostrRelay(
     [publishEvent, relayUrls],
   );
 
-  return { notes, profiles, reactions, status, relayUrls, pool, cache, publishEvent, sendReaction, sendRepost };
+  return { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, publishEvent, sendReaction, sendRepost };
 }

--- a/apps/web/app/hooks/useRecentEmojis.ts
+++ b/apps/web/app/hooks/useRecentEmojis.ts
@@ -3,6 +3,11 @@ import type { SimplePool } from "nostr-tools/pool";
 import type { Event } from "nostr-tools/core";
 import type { SubCloser } from "nostr-tools/abstract-pool";
 
+export interface RecentEmoji {
+  emoji: string;       // Unicode emoji or ":shortcode:"
+  imageUrl?: string;   // Only for custom emojis
+}
+
 /** contentが単一のUnicode絵文字かを判定する（Intl.Segmenter使用） */
 function isUnicodeEmoji(content: string): boolean {
   if (content.length === 0) return false;
@@ -13,23 +18,34 @@ function isUnicodeEmoji(content: string): boolean {
   return /\p{Extended_Pictographic}/u.test(content) || /\p{Regional_Indicator}/u.test(content) || /\u20e3/u.test(content);
 }
 
-/** 最近使った絵文字として有効かを判定する（+, -, 空文字, :shortcode: を除外、Unicode絵文字のみ） */
+/** :shortcode: 形式のカスタム絵文字かを判定する */
+function isCustomEmojiShortcode(content: string): boolean {
+  return content.startsWith(":") && content.endsWith(":") && content.length > 2;
+}
+
+/** 最近使った絵文字として有効かを判定する（+, -, 空文字を除外、Unicode絵文字またはカスタム絵文字） */
 function isValidRecentEmoji(content: string): boolean {
   // +, -, 空文字を除外
   if (content === "+" || content === "-" || content === "") return false;
 
-  // :shortcode: 形式を除外
-  if (content.startsWith(":") && content.endsWith(":") && content.length > 2) return false;
+  // Unicode絵文字またはカスタム絵文字(:shortcode:形式)を対象
+  return isUnicodeEmoji(content) || isCustomEmojiShortcode(content);
+}
 
-  // Unicode絵文字のみ対象
-  return isUnicodeEmoji(content);
+/** イベントのタグからカスタム絵文字のURLを抽出する */
+function extractCustomEmojiUrl(emoji: string, tags: string[][]): string | undefined {
+  if (!isCustomEmojiShortcode(emoji)) return undefined;
+  const shortcode = emoji.slice(1, -1);
+  const emojiTag = tags.find(tag => tag[0] === "emoji" && tag[1] === shortcode && tag[2]);
+  return emojiTag?.[2];
 }
 
 /**
- * 自分の最近のリアクションからユニークなUnicode絵文字をMRU順で取得するhook
+ * 自分の最近のリアクションからユニークな絵文字をMRU順で取得するhook
  *
  * - kind:7の最新50件を取得し、oneose後にサブスクリプションを閉じる
- * - `+`, `-`, 空文字, `:shortcode:` 形式は除外
+ * - `+`, `-`, 空文字は除外
+ * - Unicode絵文字とカスタム絵文字（:shortcode:形式）を対象
  * - 最大8個を返す
  * - `addEmoji` で楽観的にリストを更新できる
  */
@@ -37,8 +53,8 @@ export function useRecentEmojis(
   pool: SimplePool | null,
   relayUrls: string[],
   pubkey: string | null,
-): { recentEmojis: string[]; addEmoji: (emoji: string) => void } {
-  const [recentEmojis, setRecentEmojis] = useState<string[]>([]);
+): { recentEmojis: RecentEmoji[]; addEmoji: (emoji: string, imageUrl?: string) => void } {
+  const [recentEmojis, setRecentEmojis] = useState<RecentEmoji[]>([]);
 
   useEffect(() => {
     if (!pool || relayUrls.length === 0 || !pubkey) return;
@@ -64,7 +80,7 @@ export function useRecentEmojis(
 
           // ユニーク絵文字をMRU順で抽出
           const seen = new Set<string>();
-          const emojis: string[] = [];
+          const emojis: RecentEmoji[] = [];
 
           for (const evt of events) {
             const content = evt.content;
@@ -73,8 +89,9 @@ export function useRecentEmojis(
 
             if (!seen.has(content)) {
               seen.add(content);
-              emojis.push(content);
-              if (emojis.length >= 8) break;
+              const imageUrl = extractCustomEmojiUrl(content, evt.tags);
+              emojis.push({ emoji: content, imageUrl });
+              if (emojis.length >= 50) break;
             }
           }
 
@@ -104,12 +121,12 @@ export function useRecentEmojis(
     };
   }, [pool, relayUrls, pubkey]);
 
-  const addEmoji = useCallback((emoji: string) => {
+  const addEmoji = useCallback((emoji: string, imageUrl?: string) => {
     if (!isValidRecentEmoji(emoji)) return;
 
     setRecentEmojis((prev) => {
-      const filtered = prev.filter((e) => e !== emoji);
-      return [emoji, ...filtered].slice(0, 8);
+      const filtered = prev.filter((e) => e.emoji !== emoji);
+      return [{ emoji, imageUrl }, ...filtered].slice(0, 50);
     });
   }, []);
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,13 +11,13 @@ export default function Home() {
   const { pubkey, npub, nip07Available, autoLoading, login, logout } = useAuth();
   // eventId → slotId のマッピング（publish時に登録し、リレー到着時に参照する）
   const publishedSlotMapRef = useRef<Map<string, string>>(new Map());
-  const { notes, profiles, reactions, status, relayUrls, pool, cache, publishEvent, sendReaction, sendRepost } = useNostrRelay(pubkey, publishedSlotMapRef);
+  const { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, publishEvent, sendReaction, sendRepost } = useNostrRelay(pubkey, publishedSlotMapRef);
   const { filteredNotes, threadCards, isProcessing } = useThreadCards(notes, pubkey, relayUrls, pool, status, cache, publishedSlotMapRef);
   const { recentEmojis, addEmoji } = useRecentEmojis(pool, relayUrls, pubkey);
 
   const handleSendReaction = useCallback(
     async (targetEventId: string, targetPubkey: string, emoji: string, imageUrl?: string) => {
-      addEmoji(emoji); // 楽観的に即座に更新
+      addEmoji(emoji, imageUrl); // 楽観的に即座に更新
       await sendReaction(targetEventId, targetPubkey, emoji, imageUrl);
     },
     [sendReaction, addEmoji],
@@ -42,6 +42,8 @@ export default function Home() {
         onLogout={logout}
         isProcessing={isProcessing}
         recentEmojis={recentEmojis}
+        emojiSets={emojiSets}
+        looseEmojis={looseEmojis}
       />
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-nostr-relay-feat-gravity",
+  "name": "my-nostr-relay-feat-custom-emoji-reaction",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
## 概要
NIP-51 kind 10030（ユーザー絵文字パレット）と kind 30030（絵文字セット）を購読し、絵文字ピッカーからカスタム絵文字を選んでリアクション送信できるようにする。

## 変更内容

### 新規
- `useCustomEmojis` hook: kind 10030/30030 購読、emojiSets/looseEmojis を返却

### 変更
- `EmojiPickerPopover`: 絵文字セットごとのセクション、マイ絵文字セクション、検索対応
- `useRecentEmojis`: カスタム絵文字（:shortcode:）も最近使った絵文字に含める
- `ActionBar`/`NoteCard`/`ThreadCard`/`LiveCanvas`/`page.tsx`: props チェーン接続

### 変更なし
- `sendReaction` — 既にカスタム絵文字対応済み
- `useNostrReactions` — 受信側は既に動いている

## 関連NIP
- NIP-25: Reactions（kind 7）
- NIP-30: Custom Emoji
- NIP-51: Lists（kind 10030 Emojis, kind 30030 Emoji Sets）

## UIイメージ
絵文字ピッカーに以下のセクションが追加:
- 絵文字セットごとのセクション（kind 30030 の title/d-tag で命名）
- マイ絵文字（kind 10030 で直接登録された絵文字）
- 検索時はショートコードでカスタム絵文字もフィルタ
