### PR TITLE
fix: リアクション者のプロフィールをhover時に取得する

### DIFF
--- a/apps/web/app/components/LiveCanvas.tsx
+++ b/apps/web/app/components/LiveCanvas.tsx
@@ -52,13 +52,14 @@ interface LiveCanvasProps {
   recentEmojis: RecentEmoji[];
   emojiSets: EmojiSet[];
   looseEmojis: CustomEmoji[];
+  fetchProfiles: (pubkeys: string[]) => void;
 }
 
 function calcColumnCount(width: number): number {
   return Math.max(1, Math.floor(width / COLUMN_WIDTH));
 }
 
-export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis, emojiSets, looseEmojis }: LiveCanvasProps) {
+export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis, emojiSets, looseEmojis, fetchProfiles }: LiveCanvasProps) {
   const [columnCount, setColumnCount] = useState(1);
   const [holdSet, setHoldSet] = useState<Set<string>>(() => new Set());
 
@@ -499,6 +500,7 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
                               recentEmojis={recentEmojis}
                               emojiSets={emojiSets}
                               looseEmojis={looseEmojis}
+                              fetchProfiles={fetchProfiles}
                               onReaction={(targetEventId, targetPubkey, emoji, imageUrl) => {
                                 sendReaction(targetEventId, targetPubkey, emoji, imageUrl).catch(console.error);
                               }}
@@ -527,6 +529,7 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
                               recentEmojis={recentEmojis}
                               emojiSets={emojiSets}
                               looseEmojis={looseEmojis}
+                              fetchProfiles={fetchProfiles}
                               reposterProfile={note.repostInfo ? profiles.get(note.repostInfo.reposterPubkey) : undefined}
                               reactions={reactions.get(note.eventId)}
                               myPubkey={pubkey}

--- a/apps/web/app/components/NoteCard.tsx
+++ b/apps/web/app/components/NoteCard.tsx
@@ -75,9 +75,11 @@ interface NoteCardProps {
   emojiSets?: EmojiSet[];
   /** 個別のカスタム絵文字 */
   looseEmojis?: CustomEmoji[];
+  /** プロフィール取得関数（未取得のpubkeyのプロフィールをフェッチする） */
+  fetchProfiles?: (pubkeys: string[]) => void;
 }
 
-export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, onReaction, onRepost, cache, profiles, onHeightChange, onHold, onRelease, onReplyPublish, publishEvent, myProfile, onQuote, recentEmojis, emojiSets, looseEmojis }: NoteCardProps) {
+export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, onReaction, onRepost, cache, profiles, onHeightChange, onHold, onRelease, onReplyPublish, publishEvent, myProfile, onQuote, recentEmojis, emojiSets, looseEmojis, fetchProfiles }: NoteCardProps) {
   const displayName =
     profile?.display_name || profile?.name || shortenPubkey(note.pubkey);
 
@@ -217,11 +219,22 @@ export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, 
 
   // リアクションバッジのツールチップ用イベントハンドラー
   const handleBadgeMouseEnter = useCallback((emoji: string) => {
+    // リアクション者のプロフィールを先行取得
+    if (fetchProfiles && reactions) {
+      const entry = reactions.get(emoji);
+      if (entry) {
+        const unknownPubkeys = Array.from(entry.pubkeys).filter(pk => !profiles?.has(pk));
+        if (unknownPubkeys.length > 0) {
+          fetchProfiles(unknownPubkeys);
+        }
+      }
+    }
+
     if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
     hoverTimerRef.current = setTimeout(() => {
       setActiveTooltipEmoji(emoji);
     }, 500);
-  }, []);
+  }, [fetchProfiles, reactions, profiles]);
 
   const handleBadgeMouseLeave = useCallback(() => {
     if (hoverTimerRef.current) {

--- a/apps/web/app/components/ThreadCard.tsx
+++ b/apps/web/app/components/ThreadCard.tsx
@@ -89,6 +89,8 @@ interface ThreadCardProps {
   emojiSets?: EmojiSet[];
   /** 個別のカスタム絵文字 */
   looseEmojis?: CustomEmoji[];
+  /** プロフィール取得関数（未取得のpubkeyのプロフィールをフェッチする） */
+  fetchProfiles?: (pubkeys: string[]) => void;
 }
 
 export function ThreadCard({
@@ -108,6 +110,7 @@ export function ThreadCard({
   recentEmojis,
   emojiSets,
   looseEmojis,
+  fetchProfiles,
 }: ThreadCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
@@ -279,6 +282,7 @@ export function ThreadCard({
             recentEmojis={recentEmojis}
             emojiSets={emojiSets}
             looseEmojis={looseEmojis}
+            fetchProfiles={fetchProfiles}
           />
         );
       })}
@@ -353,6 +357,8 @@ interface ThreadNoteItemProps {
   emojiSets?: EmojiSet[];
   /** 個別のカスタム絵文字 */
   looseEmojis?: CustomEmoji[];
+  /** プロフィール取得関数 */
+  fetchProfiles?: (pubkeys: string[]) => void;
 }
 
 function ThreadNoteItem({
@@ -375,6 +381,7 @@ function ThreadNoteItem({
   recentEmojis,
   emojiSets,
   looseEmojis,
+  fetchProfiles,
 }: ThreadNoteItemProps) {
   const profile = profiles.get(note.pubkey);
   const displayName =
@@ -428,11 +435,22 @@ function ThreadNoteItem({
 
   // リアクションバッジのツールチップ用イベントハンドラー
   const handleBadgeMouseEnter = useCallback((emoji: string) => {
+    // リアクション者のプロフィールを先行取得
+    if (fetchProfiles && noteReactions) {
+      const entry = noteReactions.get(emoji);
+      if (entry) {
+        const unknownPubkeys = Array.from(entry.pubkeys).filter(pk => !profiles?.has(pk));
+        if (unknownPubkeys.length > 0) {
+          fetchProfiles(unknownPubkeys);
+        }
+      }
+    }
+
     if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
     hoverTimerRef.current = setTimeout(() => {
       setActiveTooltipEmoji(emoji);
     }, 500);
-  }, []);
+  }, [fetchProfiles, noteReactions, profiles]);
 
   const handleBadgeMouseLeave = useCallback(() => {
     if (hoverTimerRef.current) {

--- a/apps/web/app/hooks/useNostrRelay.ts
+++ b/apps/web/app/hooks/useNostrRelay.ts
@@ -27,6 +27,7 @@ interface UseNostrRelayResult {
   cache: EventCache;
   emojiSets: EmojiSet[];
   looseEmojis: CustomEmoji[];
+  fetchProfiles: (pubkeys: string[]) => void;
   publishEvent: (event: NostrEvent) => Promise<void>;
   sendReaction: (targetEventId: string, targetPubkey: string, emoji: string, imageUrl?: string) => Promise<void>;
   sendRepost: (targetEventId: string, targetPubkey: string, originalEvent: NostrEvent) => Promise<void>;
@@ -156,5 +157,5 @@ export function useNostrRelay(
     [publishEvent, relayUrls],
   );
 
-  return { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, publishEvent, sendReaction, sendRepost };
+  return { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, fetchProfiles, publishEvent, sendReaction, sendRepost };
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   const { pubkey, npub, nip07Available, autoLoading, login, logout } = useAuth();
   // eventId → slotId のマッピング（publish時に登録し、リレー到着時に参照する）
   const publishedSlotMapRef = useRef<Map<string, string>>(new Map());
-  const { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, publishEvent, sendReaction, sendRepost } = useNostrRelay(pubkey, publishedSlotMapRef);
+  const { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, fetchProfiles, publishEvent, sendReaction, sendRepost } = useNostrRelay(pubkey, publishedSlotMapRef);
   const { filteredNotes, threadCards, isProcessing } = useThreadCards(notes, pubkey, relayUrls, pool, status, cache, publishedSlotMapRef);
   const { recentEmojis, addEmoji } = useRecentEmojis(pool, relayUrls, pubkey);
 
@@ -44,6 +44,7 @@ export default function Home() {
         recentEmojis={recentEmojis}
         emojiSets={emojiSets}
         looseEmojis={looseEmojis}
+        fetchProfiles={fetchProfiles}
       />
     );
   }


### PR DESCRIPTION
## 概要
リアクションバッジにhoverしたときのツールチップに表示されるリアクション者のプロフィールが取得されない問題を修正。

## 問題
- `useNostrProfiles` は初期化時に `followPubkeys`（フォロー中ユーザー）のkind:0のみをsubscribeしていた
- `fetchProfiles` 関数で追加のプロフィール取得が可能だが、リアクション者のpubkeyに対しては呼ばれていなかった
- ノート投稿者・リポスト元投稿者・引用ノート投稿者のプロフィールは取得済みだが、リアクション者のプロフィールだけが漏れていた

## 修正内容
- `useNostrRelay` から `fetchProfiles` を外部公開
- props chain で `page.tsx` → `LiveCanvas` → `NoteCard` / `ThreadCard` → `ThreadNoteItem` に伝搬
- `handleBadgeMouseEnter` でhover時に未取得のpubkeyを検出し `fetchProfiles` を呼び出す
- 既に取得済みのプロフィールは呼び出し側（`profiles.has(pk)`）と `fetchProfiles` 内部（`profilesRef.current.has(pk)`）の両方でスキップ

## 変更ファイル
- `apps/web/app/hooks/useNostrRelay.ts` — `fetchProfiles` を返り値に追加
- `apps/web/app/page.tsx` — `fetchProfiles` を受け取り `LiveCanvas` に渡す
- `apps/web/app/components/LiveCanvas.tsx` — `NoteCard` / `ThreadCard` に `fetchProfiles` を渡す
- `apps/web/app/components/NoteCard.tsx` — hover時にプロフィール取得
- `apps/web/app/components/ThreadCard.tsx` — hover時にプロフィール取得（`ThreadNoteItem` にも伝搬）