### PR TITLE
feat: add user profile modal

### DIFF
--- a/apps/web/app/components/LiveCanvas.tsx
+++ b/apps/web/app/components/LiveCanvas.tsx
@@ -26,9 +26,11 @@ import { ComposeCard } from "./ComposeCard";
 import { CanvasHeader } from "./CanvasHeader";
 import { EmptyState } from "./EmptyState";
 import type { NostrEvent } from "../types/nostr";
+import type { Event } from "nostr-tools/core";
 import type { EventCache } from "../hooks/useEventCache";
 import type { CustomEmoji, EmojiSet } from "../hooks/useCustomEmojis";
 import type { RecentEmoji } from "../hooks/useRecentEmojis";
+import { UserProfileModal } from "./UserProfileModal";
 
 interface LiveCanvasProps {
   notes: NoteCardType[];
@@ -53,15 +55,17 @@ interface LiveCanvasProps {
   emojiSets: EmojiSet[];
   looseEmojis: CustomEmoji[];
   fetchProfiles: (pubkeys: string[]) => void;
+  fetchUserRecentNotes: (pubkey: string) => Promise<Event[]>;
 }
 
 function calcColumnCount(width: number): number {
   return Math.max(1, Math.floor(width / COLUMN_WIDTH));
 }
 
-export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis, emojiSets, looseEmojis, fetchProfiles }: LiveCanvasProps) {
+export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis, emojiSets, looseEmojis, fetchProfiles, fetchUserRecentNotes }: LiveCanvasProps) {
   const [columnCount, setColumnCount] = useState(1);
   const [holdSet, setHoldSet] = useState<Set<string>>(() => new Set());
+  const [profileModalPubkey, setProfileModalPubkey] = useState<string | null>(null);
 
   /** カードをホールド状態にする */
   const holdCard = useCallback((slotId: string) => {
@@ -501,6 +505,7 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
                               emojiSets={emojiSets}
                               looseEmojis={looseEmojis}
                               fetchProfiles={fetchProfiles}
+                              onProfileClick={(targetPubkey) => setProfileModalPubkey(targetPubkey)}
                               onReaction={(targetEventId, targetPubkey, emoji, imageUrl) => {
                                 sendReaction(targetEventId, targetPubkey, emoji, imageUrl).catch(console.error);
                               }}
@@ -530,6 +535,7 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
                               emojiSets={emojiSets}
                               looseEmojis={looseEmojis}
                               fetchProfiles={fetchProfiles}
+                              onProfileClick={(targetPubkey) => setProfileModalPubkey(targetPubkey)}
                               reposterProfile={note.repostInfo ? profiles.get(note.repostInfo.reposterPubkey) : undefined}
                               reactions={reactions.get(note.eventId)}
                               myPubkey={pubkey}
@@ -578,6 +584,19 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
           );
         })()}
       </main>
+
+      {profileModalPubkey && (
+        <UserProfileModal
+          pubkey={profileModalPubkey}
+          profile={profiles.get(profileModalPubkey)}
+          isOpen={!!profileModalPubkey}
+          onClose={() => setProfileModalPubkey(null)}
+          fetchProfiles={fetchProfiles}
+          fetchUserRecentNotes={fetchUserRecentNotes}
+          cache={cache}
+          profiles={profiles}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/app/components/NoteCard.tsx
+++ b/apps/web/app/components/NoteCard.tsx
@@ -52,9 +52,11 @@ interface NoteCardProps {
   looseEmojis?: CustomEmoji[];
   /** プロフィール取得関数（未取得のpubkeyのプロフィールをフェッチする） */
   fetchProfiles?: (pubkeys: string[]) => void;
+  /** アバターまたは表示名クリック時のハンドラ */
+  onProfileClick?: (pubkey: string) => void;
 }
 
-export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, onReaction, onRepost, cache, profiles, onHeightChange, onHold, onRelease, onReplyPublish, publishEvent, myProfile, onQuote, recentEmojis, emojiSets, looseEmojis, fetchProfiles }: NoteCardProps) {
+export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, onReaction, onRepost, cache, profiles, onHeightChange, onHold, onRelease, onReplyPublish, publishEvent, myProfile, onQuote, recentEmojis, emojiSets, looseEmojis, fetchProfiles, onProfileClick }: NoteCardProps) {
   const displayName = resolveProfileDisplayName(note.pubkey, profile);
   const cardRef = useRef<HTMLDivElement>(null);
   const [isActionBarOpen, setIsActionBarOpen] = useState(false);
@@ -265,6 +267,10 @@ export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, 
         onRelease={onRelease}
         cache={cache}
         profiles={profiles}
+        onProfileClick={onProfileClick ? (pubkey, event) => {
+          event.stopPropagation();
+          onProfileClick(pubkey);
+        } : undefined}
       />
 
       {/* リアクションバッジ */}

--- a/apps/web/app/components/NoteCard.tsx
+++ b/apps/web/app/components/NoteCard.tsx
@@ -1,40 +1,15 @@
 "use client";
 
 import { useRef, useEffect, useState, useCallback } from "react";
-import Image from "next/image";
 import type { NoteCard as NoteCardType, NostrProfile } from "../lib/types";
 import type { NostrEvent } from "../types/nostr";
-import { ContentRenderer } from "./content/ContentRenderer";
 import { ActionBar } from "./ActionBar";
+import { NoteCardContent, resolveProfileDisplayName } from "./NoteCardContent";
 import { ReplyCompose } from "./ReplyCompose";
 import { ReactionTooltip } from "./ReactionTooltip";
 import type { EventCache } from "../hooks/useEventCache";
 import type { CustomEmoji, EmojiSet } from "../hooks/useCustomEmojis";
 import type { RecentEmoji } from "../hooks/useRecentEmojis";
-
-/** npubの省略表示を生成 */
-function shortenPubkey(pubkey: string): string {
-  if (pubkey.length <= 12) return pubkey;
-  return `${pubkey.slice(0, 8)}…${pubkey.slice(-4)}`;
-}
-
-/** 相対時刻を表示する（"3分前", "1時間前" など） */
-function relativeTime(unixTimestamp: number): string {
-  const now = Math.floor(Date.now() / 1000);
-  const diffSec = now - unixTimestamp;
-
-  const rtf = new Intl.RelativeTimeFormat("ja", { numeric: "auto" });
-
-  if (diffSec < 60) {
-    return rtf.format(-diffSec, "second");
-  } else if (diffSec < 3600) {
-    return rtf.format(-Math.floor(diffSec / 60), "minute");
-  } else if (diffSec < 86400) {
-    return rtf.format(-Math.floor(diffSec / 3600), "hour");
-  } else {
-    return rtf.format(-Math.floor(diffSec / 86400), "day");
-  }
-}
 
 interface NoteCardProps {
   note: NoteCardType;
@@ -80,14 +55,7 @@ interface NoteCardProps {
 }
 
 export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, onReaction, onRepost, cache, profiles, onHeightChange, onHold, onRelease, onReplyPublish, publishEvent, myProfile, onQuote, recentEmojis, emojiSets, looseEmojis, fetchProfiles }: NoteCardProps) {
-  const displayName =
-    profile?.display_name || profile?.name || shortenPubkey(note.pubkey);
-
-  // リポスター名の表示（display_name > name > 短縮pubkey）
-  const reposterName = note.repostInfo
-    ? reposterProfile?.display_name || reposterProfile?.name || shortenPubkey(note.repostInfo.reposterPubkey)
-    : undefined;
-  const avatarUrl = profile?.picture;
+  const displayName = resolveProfileDisplayName(note.pubkey, profile);
   const cardRef = useRef<HTMLDivElement>(null);
   const [isActionBarOpen, setIsActionBarOpen] = useState(false);
   const [isReplyMode, setIsReplyMode] = useState(false);
@@ -289,47 +257,15 @@ export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, 
           🧵 スレッド
         </div>
       )}
-      {/* リポスト情報（カード最上部） */}
-      {note.repostInfo && (
-        <div className="mb-2 text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
-          <span>🔁</span>
-          <span>{reposterName}がリポスト</span>
-        </div>
-      )}
-
-      {/* ヘッダー: アバター + 名前 + 時刻 */}
-      <div className="flex items-center gap-3 mb-2">
-        {/* アバター */}
-        {avatarUrl ? (
-          <Image
-            src={avatarUrl}
-            alt={displayName}
-            width={32}
-            height={32}
-            className="h-8 w-8 shrink-0 rounded-full object-cover"
-            unoptimized
-          />
-        ) : (
-          <div className="w-8 h-8 rounded-full bg-gradient-to-br from-purple-400 to-blue-500 flex items-center justify-center flex-shrink-0">
-            <span className="text-white text-xs font-bold">
-              {displayName.charAt(0).toUpperCase()}
-            </span>
-          </div>
-        )}
-
-        {/* 名前と時刻 */}
-        <div className="flex flex-col min-w-0 flex-1">
-          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
-            {displayName}
-          </span>
-          <span className="text-xs text-gray-500 dark:text-gray-400">
-            {relativeTime(note.created_at)}
-          </span>
-        </div>
-      </div>
-
-      {/* テキスト内容（ContentRendererでリッチコンテンツを描画） */}
-      <ContentRenderer content={note.content} onHold={onHold} onRelease={onRelease} cache={cache} profiles={profiles} tags={note.tags} />
+      <NoteCardContent
+        note={note}
+        profile={profile}
+        reposterProfile={reposterProfile}
+        onHold={onHold}
+        onRelease={onRelease}
+        cache={cache}
+        profiles={profiles}
+      />
 
       {/* リアクションバッジ */}
       {reactions && reactions.size > 0 && (

--- a/apps/web/app/components/NoteCardContent.tsx
+++ b/apps/web/app/components/NoteCardContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
 import Image from "next/image";
 import { ContentRenderer } from "./content/ContentRenderer";
 import type { EventCache } from "../hooks/useEventCache";
@@ -55,6 +56,7 @@ interface NoteCardContentProps {
   onRelease?: () => void;
   cache?: EventCache;
   profiles?: Map<string, NostrProfile>;
+  onProfileClick?: (pubkey: string, event: ReactMouseEvent | ReactKeyboardEvent) => void;
 }
 
 export function NoteCardContent({
@@ -67,6 +69,7 @@ export function NoteCardContent({
   onRelease,
   cache,
   profiles,
+  onProfileClick,
 }: NoteCardContentProps) {
   const isCompact = variant === "compact";
   const displayName = resolveProfileDisplayName(note.pubkey, profile);
@@ -74,6 +77,10 @@ export function NoteCardContent({
     ? resolveProfileDisplayName(note.repostInfo.reposterPubkey, reposterProfile)
     : undefined;
   const avatarUrl = profile?.picture;
+
+  const avatarButtonClass = isCompact
+    ? "h-6 w-6 shrink-0 rounded-full"
+    : "h-8 w-8 shrink-0 rounded-full";
 
   return (
     <>
@@ -91,7 +98,36 @@ export function NoteCardContent({
       )}
 
       <div className={`flex items-center ${isCompact ? "gap-2 mb-1" : "gap-3 mb-2"}`}>
-        {avatarUrl ? (
+        {onProfileClick ? (
+          <button
+            type="button"
+            onClick={(event) => onProfileClick(note.pubkey, event)}
+            className={`${avatarButtonClass} rounded-full transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-purple-400`}
+            aria-label={`${displayName}のプロフィールを開く`}
+          >
+            {avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                alt={displayName}
+                width={isCompact ? 24 : 32}
+                height={isCompact ? 24 : 32}
+                className={isCompact
+                  ? "h-6 w-6 shrink-0 rounded-full object-cover"
+                  : "h-8 w-8 shrink-0 rounded-full object-cover"}
+                unoptimized
+              />
+            ) : (
+              <div className={isCompact
+                ? "w-6 h-6 rounded-full bg-gradient-to-br from-purple-400 to-blue-500 flex items-center justify-center flex-shrink-0"
+                : "w-8 h-8 rounded-full bg-gradient-to-br from-purple-400 to-blue-500 flex items-center justify-center flex-shrink-0"}
+              >
+                <span className={isCompact ? "text-white text-[10px] font-bold" : "text-white text-xs font-bold"}>
+                  {displayName.charAt(0).toUpperCase()}
+                </span>
+              </div>
+            )}
+          </button>
+        ) : avatarUrl ? (
           <Image
             src={avatarUrl}
             alt={displayName}
@@ -115,18 +151,38 @@ export function NoteCardContent({
 
         {isCompact ? (
           <div className="flex items-baseline gap-1.5 min-w-0 flex-1">
-            <span className="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate">
-              {displayName}
-            </span>
+            {onProfileClick ? (
+              <button
+                type="button"
+                onClick={(event) => onProfileClick(note.pubkey, event)}
+                className="min-w-0 truncate text-left text-xs font-semibold text-gray-900 transition-colors hover:text-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-400 dark:text-gray-100 dark:hover:text-purple-400"
+              >
+                {displayName}
+              </button>
+            ) : (
+              <span className="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate">
+                {displayName}
+              </span>
+            )}
             <span className="text-[11px] text-gray-400 dark:text-gray-500 flex-shrink-0">
               {relativeTime(note.created_at)}
             </span>
           </div>
         ) : (
           <div className="flex flex-col min-w-0 flex-1">
-            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
-              {displayName}
-            </span>
+            {onProfileClick ? (
+              <button
+                type="button"
+                onClick={(event) => onProfileClick(note.pubkey, event)}
+                className="truncate text-left text-sm font-semibold text-gray-900 transition-colors hover:text-purple-600 focus:outline-none focus:ring-2 focus:ring-purple-400 dark:text-gray-100 dark:hover:text-purple-400"
+              >
+                {displayName}
+              </button>
+            ) : (
+              <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                {displayName}
+              </span>
+            )}
             <span className="text-xs text-gray-500 dark:text-gray-400">
               {relativeTime(note.created_at)}
             </span>

--- a/apps/web/app/components/NoteCardContent.tsx
+++ b/apps/web/app/components/NoteCardContent.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Image from "next/image";
+import { ContentRenderer } from "./content/ContentRenderer";
+import type { EventCache } from "../hooks/useEventCache";
+import type { NostrProfile } from "../lib/types";
+
+export interface NoteCardContentNote {
+  pubkey: string;
+  content: string;
+  created_at: number;
+  tags: string[][];
+  repostInfo?: {
+    reposterPubkey: string;
+    repostedAt: number;
+  };
+}
+
+export function shortenPubkey(pubkey: string): string {
+  if (pubkey.length <= 12) return pubkey;
+  return `${pubkey.slice(0, 8)}…${pubkey.slice(-4)}`;
+}
+
+export function relativeTime(unixTimestamp: number): string {
+  const now = Math.floor(Date.now() / 1000);
+  const diffSec = now - unixTimestamp;
+
+  const rtf = new Intl.RelativeTimeFormat("ja", { numeric: "auto" });
+
+  if (diffSec < 60) {
+    return rtf.format(-diffSec, "second");
+  } else if (diffSec < 3600) {
+    return rtf.format(-Math.floor(diffSec / 60), "minute");
+  } else if (diffSec < 86400) {
+    return rtf.format(-Math.floor(diffSec / 3600), "hour");
+  } else {
+    return rtf.format(-Math.floor(diffSec / 86400), "day");
+  }
+}
+
+export function resolveProfileDisplayName(
+  pubkey: string,
+  profile?: NostrProfile,
+): string {
+  return profile?.display_name || profile?.name || shortenPubkey(pubkey);
+}
+
+interface NoteCardContentProps {
+  note: NoteCardContentNote;
+  profile?: NostrProfile;
+  reposterProfile?: NostrProfile;
+  replyToName?: string | null;
+  variant?: "default" | "compact";
+  onHold?: () => void;
+  onRelease?: () => void;
+  cache?: EventCache;
+  profiles?: Map<string, NostrProfile>;
+}
+
+export function NoteCardContent({
+  note,
+  profile,
+  reposterProfile,
+  replyToName,
+  variant = "default",
+  onHold,
+  onRelease,
+  cache,
+  profiles,
+}: NoteCardContentProps) {
+  const isCompact = variant === "compact";
+  const displayName = resolveProfileDisplayName(note.pubkey, profile);
+  const reposterName = note.repostInfo
+    ? resolveProfileDisplayName(note.repostInfo.reposterPubkey, reposterProfile)
+    : undefined;
+  const avatarUrl = profile?.picture;
+
+  return (
+    <>
+      {replyToName && isCompact && (
+        <div className="text-[11px] text-gray-400 dark:text-gray-500 mb-0.5 ml-8">
+          ↩ {replyToName}
+        </div>
+      )}
+
+      {note.repostInfo && !isCompact && (
+        <div className="mb-2 text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+          <span>🔁</span>
+          <span>{reposterName}がリポスト</span>
+        </div>
+      )}
+
+      <div className={`flex items-center ${isCompact ? "gap-2 mb-1" : "gap-3 mb-2"}`}>
+        {avatarUrl ? (
+          <Image
+            src={avatarUrl}
+            alt={displayName}
+            width={isCompact ? 24 : 32}
+            height={isCompact ? 24 : 32}
+            className={isCompact
+              ? "h-6 w-6 shrink-0 rounded-full object-cover"
+              : "h-8 w-8 shrink-0 rounded-full object-cover"}
+            unoptimized
+          />
+        ) : (
+          <div className={isCompact
+            ? "w-6 h-6 rounded-full bg-gradient-to-br from-purple-400 to-blue-500 flex items-center justify-center flex-shrink-0"
+            : "w-8 h-8 rounded-full bg-gradient-to-br from-purple-400 to-blue-500 flex items-center justify-center flex-shrink-0"}
+          >
+            <span className={isCompact ? "text-white text-[10px] font-bold" : "text-white text-xs font-bold"}>
+              {displayName.charAt(0).toUpperCase()}
+            </span>
+          </div>
+        )}
+
+        {isCompact ? (
+          <div className="flex items-baseline gap-1.5 min-w-0 flex-1">
+            <span className="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate">
+              {displayName}
+            </span>
+            <span className="text-[11px] text-gray-400 dark:text-gray-500 flex-shrink-0">
+              {relativeTime(note.created_at)}
+            </span>
+          </div>
+        ) : (
+          <div className="flex flex-col min-w-0 flex-1">
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+              {displayName}
+            </span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {relativeTime(note.created_at)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className={isCompact ? "ml-8 text-sm" : undefined}>
+        <ContentRenderer
+          content={note.content}
+          onHold={onHold}
+          onRelease={onRelease}
+          cache={cache}
+          profiles={profiles}
+          tags={note.tags}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/components/ThreadCard.tsx
+++ b/apps/web/app/components/ThreadCard.tsx
@@ -65,6 +65,8 @@ interface ThreadCardProps {
   looseEmojis?: CustomEmoji[];
   /** プロフィール取得関数（未取得のpubkeyのプロフィールをフェッチする） */
   fetchProfiles?: (pubkeys: string[]) => void;
+  /** アバターまたは表示名クリック時のハンドラ */
+  onProfileClick?: (pubkey: string) => void;
 }
 
 export function ThreadCard({
@@ -85,6 +87,7 @@ export function ThreadCard({
   emojiSets,
   looseEmojis,
   fetchProfiles,
+  onProfileClick,
 }: ThreadCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
@@ -257,6 +260,7 @@ export function ThreadCard({
             emojiSets={emojiSets}
             looseEmojis={looseEmojis}
             fetchProfiles={fetchProfiles}
+            onProfileClick={onProfileClick}
           />
         );
       })}
@@ -333,6 +337,8 @@ interface ThreadNoteItemProps {
   looseEmojis?: CustomEmoji[];
   /** プロフィール取得関数 */
   fetchProfiles?: (pubkeys: string[]) => void;
+  /** アバターまたは表示名クリック時のハンドラ */
+  onProfileClick?: (pubkey: string) => void;
 }
 
 function ThreadNoteItem({
@@ -356,6 +362,7 @@ function ThreadNoteItem({
   emojiSets,
   looseEmojis,
   fetchProfiles,
+  onProfileClick,
 }: ThreadNoteItemProps) {
   const profile = profiles.get(note.pubkey);
 
@@ -480,6 +487,10 @@ function ThreadNoteItem({
           onRelease={onRelease}
           cache={cache}
           profiles={profiles}
+          onProfileClick={onProfileClick ? (pubkey, event) => {
+            event.stopPropagation();
+            onProfileClick(pubkey);
+          } : undefined}
         />
 
         {/* リアクションバッジ */}

--- a/apps/web/app/components/ThreadCard.tsx
+++ b/apps/web/app/components/ThreadCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRef, useEffect, useState, useCallback } from "react";
-import Image from "next/image";
 import type {
   ThreadCard as ThreadCardType,
   ThreadNote,
@@ -9,37 +8,13 @@ import type {
   Reactions,
 } from "../lib/types";
 import type { NostrEvent } from "../types/nostr";
-import { ContentRenderer } from "./content/ContentRenderer";
 import type { EventCache } from "../hooks/useEventCache";
 import { ActionBar } from "./ActionBar";
+import { NoteCardContent, resolveProfileDisplayName } from "./NoteCardContent";
 import { ReplyCompose } from "./ReplyCompose";
 import { ReactionTooltip } from "./ReactionTooltip";
 import type { CustomEmoji, EmojiSet } from "../hooks/useCustomEmojis";
 import type { RecentEmoji } from "../hooks/useRecentEmojis";
-
-/** npubの省略表示を生成 */
-function shortenPubkey(pubkey: string): string {
-  if (pubkey.length <= 12) return pubkey;
-  return `${pubkey.slice(0, 8)}…${pubkey.slice(-4)}`;
-}
-
-/** 相対時刻を表示する（"3分前", "1時間前" など） */
-function relativeTime(unixTimestamp: number): string {
-  const now = Math.floor(Date.now() / 1000);
-  const diffSec = now - unixTimestamp;
-
-  const rtf = new Intl.RelativeTimeFormat("ja", { numeric: "auto" });
-
-  if (diffSec < 60) {
-    return rtf.format(-diffSec, "second");
-  } else if (diffSec < 3600) {
-    return rtf.format(-Math.floor(diffSec / 60), "minute");
-  } else if (diffSec < 86400) {
-    return rtf.format(-Math.floor(diffSec / 3600), "hour");
-  } else {
-    return rtf.format(-Math.floor(diffSec / 86400), "day");
-  }
-}
 
 /** プロフィールから表示名を解決する */
 function resolveDisplayName(
@@ -47,8 +22,7 @@ function resolveDisplayName(
   profiles: Map<string, NostrProfile>,
 ): string {
   if (!pubkey) return "不明なユーザー";
-  const profile = profiles.get(pubkey);
-  return profile?.display_name || profile?.name || shortenPubkey(pubkey);
+  return resolveProfileDisplayName(pubkey, profiles.get(pubkey));
 }
 
 interface ThreadCardProps {
@@ -384,9 +358,6 @@ function ThreadNoteItem({
   fetchProfiles,
 }: ThreadNoteItemProps) {
   const profile = profiles.get(note.pubkey);
-  const displayName =
-    profile?.display_name || profile?.name || shortenPubkey(note.pubkey);
-  const avatarUrl = profile?.picture;
 
   // 返信先の表示名を解決
   const replyToName = note.replyTo
@@ -500,53 +471,16 @@ function ThreadNoteItem({
           isLast ? "pb-3 rounded-b-xl" : ""
         } ${isActive ? "bg-gray-50 dark:bg-gray-800" : ""}`}
       >
-        {/* 返信先インジケータ */}
-        {replyToName && (
-          <div className="text-[11px] text-gray-400 dark:text-gray-500 mb-0.5 ml-8">
-            ↩ {replyToName}
-          </div>
-        )}
-
-        {/* ヘッダー: アバター + 名前 + 時刻 */}
-        <div className="flex items-center gap-2 mb-1">
-          {avatarUrl ? (
-            <Image
-              src={avatarUrl}
-              alt={displayName}
-              width={24}
-              height={24}
-              className="h-6 w-6 shrink-0 rounded-full object-cover"
-              unoptimized
-            />
-          ) : (
-            <div className="w-6 h-6 rounded-full bg-gradient-to-br from-purple-400 to-blue-500 flex items-center justify-center flex-shrink-0">
-              <span className="text-white text-[10px] font-bold">
-                {displayName.charAt(0).toUpperCase()}
-              </span>
-            </div>
-          )}
-
-          <div className="flex items-baseline gap-1.5 min-w-0 flex-1">
-            <span className="text-xs font-semibold text-gray-900 dark:text-gray-100 truncate">
-              {displayName}
-            </span>
-            <span className="text-[11px] text-gray-400 dark:text-gray-500 flex-shrink-0">
-              {relativeTime(note.created_at)}
-            </span>
-          </div>
-        </div>
-
-        {/* コンテンツ */}
-        <div className="ml-8 text-sm">
-          <ContentRenderer
-            content={note.content}
-            onHold={onHold}
-            onRelease={onRelease}
-            cache={cache}
-            profiles={profiles}
-            tags={note.tags}
-          />
-        </div>
+        <NoteCardContent
+          note={note}
+          profile={profile}
+          replyToName={replyToName}
+          variant="compact"
+          onHold={onHold}
+          onRelease={onRelease}
+          cache={cache}
+          profiles={profiles}
+        />
 
         {/* リアクションバッジ */}
         {noteReactions && noteReactions.size > 0 && (

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -24,11 +24,6 @@ interface UserProfileModalProps {
 
 const RECENT_NOTES_PANEL_MIN_HEIGHT_CLASS = "min-h-[420px]";
 
-function truncateNpub(npub: string): string {
-  if (npub.length <= 20) return npub;
-  return `${npub.slice(0, 12)}...${npub.slice(-8)}`;
-}
-
 function RecentNotesLoadingSkeleton() {
   return (
     <div className={`space-y-3 ${RECENT_NOTES_PANEL_MIN_HEIGHT_CLASS}`} aria-hidden="true">
@@ -117,7 +112,7 @@ export function UserProfileModal({
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.98, y: 8 }}
         transition={{ duration: 0.2 }}
-        className="relative flex max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+        className="relative flex h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 shadow-2xl dark:border-gray-700 dark:bg-gray-900"
         onClick={(event) => event.stopPropagation()}
       >
         <button
@@ -157,7 +152,12 @@ export function UserProfileModal({
                   <span className="truncate text-sm text-gray-500 dark:text-gray-400">@{profile.name}</span>
                 )}
               </div>
-              <div className="mt-1 text-xs text-gray-500 dark:text-gray-400" title={npub}>{truncateNpub(npub)}</div>
+              <div
+                className="mt-1 break-all text-xs leading-5 text-gray-500 select-all dark:text-gray-400"
+                title={npub}
+              >
+                {npub}
+              </div>
               {profile?.nip05 && (
                 <div className="mt-2 text-sm text-purple-600 dark:text-purple-400">{profile.nip05}</div>
               )}

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -7,8 +7,9 @@ import { motion } from "framer-motion";
 import type { Event } from "nostr-tools/core";
 import type { EventCache } from "../hooks/useEventCache";
 import { useUserRecentNotes } from "../hooks/useUserRecentNotes";
+import { encodeNpub } from "../lib/nip19";
 import type { NostrProfile } from "../lib/types";
-import { NoteCardContent, resolveProfileDisplayName, shortenPubkey } from "./NoteCardContent";
+import { NoteCardContent, resolveProfileDisplayName } from "./NoteCardContent";
 
 interface UserProfileModalProps {
   pubkey: string;
@@ -19,6 +20,41 @@ interface UserProfileModalProps {
   fetchUserRecentNotes: (pubkey: string) => Promise<Event[]>;
   cache: EventCache;
   profiles: Map<string, NostrProfile>;
+}
+
+const RECENT_NOTES_PANEL_MIN_HEIGHT_CLASS = "min-h-[420px]";
+
+function truncateNpub(npub: string): string {
+  if (npub.length <= 20) return npub;
+  return `${npub.slice(0, 12)}...${npub.slice(-8)}`;
+}
+
+function RecentNotesLoadingSkeleton() {
+  return (
+    <div className={`space-y-3 ${RECENT_NOTES_PANEL_MIN_HEIGHT_CLASS}`} aria-hidden="true">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="rounded-xl border border-gray-200 bg-white px-4 py-4 dark:border-gray-700 dark:bg-gray-800"
+        >
+          <div className="animate-pulse">
+            <div className="mb-3 flex items-center gap-3">
+              <div className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700" />
+              <div className="flex-1 space-y-2">
+                <div className="h-3 w-32 rounded bg-gray-200 dark:bg-gray-700" />
+                <div className="h-2.5 w-20 rounded bg-gray-200 dark:bg-gray-700" />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <div className="h-3 w-full rounded bg-gray-200 dark:bg-gray-700" />
+              <div className="h-3 w-5/6 rounded bg-gray-200 dark:bg-gray-700" />
+              <div className="h-3 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 export function UserProfileModal({
@@ -64,6 +100,7 @@ export function UserProfileModal({
 
   const displayName = resolveProfileDisplayName(pubkey, profile);
   const avatarUrl = profile?.picture;
+  const npub = encodeNpub(pubkey);
 
   return createPortal(
     <motion.div
@@ -120,7 +157,7 @@ export function UserProfileModal({
                   <span className="truncate text-sm text-gray-500 dark:text-gray-400">@{profile.name}</span>
                 )}
               </div>
-              <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">{shortenPubkey(pubkey)}</div>
+              <div className="mt-1 text-xs text-gray-500 dark:text-gray-400" title={npub}>{truncateNpub(npub)}</div>
               {profile?.nip05 && (
                 <div className="mt-2 text-sm text-purple-600 dark:text-purple-400">{profile.nip05}</div>
               )}
@@ -142,19 +179,21 @@ export function UserProfileModal({
           </div>
 
           {isLoading ? (
-            <div className="flex items-center justify-center py-12 text-sm text-gray-500 dark:text-gray-400">
-              読み込み中...
-            </div>
+            <RecentNotesLoadingSkeleton />
           ) : error ? (
-            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
-              {error}
+            <div className={`flex items-center ${RECENT_NOTES_PANEL_MIN_HEIGHT_CLASS}`}>
+              <div className="w-full rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+                {error}
+              </div>
             </div>
           ) : notes.length === 0 ? (
-            <div className="rounded-xl border border-gray-200 bg-white px-4 py-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
-              recent note はありません
+            <div className={`flex items-center ${RECENT_NOTES_PANEL_MIN_HEIGHT_CLASS}`}>
+              <div className="w-full rounded-xl border border-gray-200 bg-white px-4 py-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
+                recent note はありません
+              </div>
             </div>
           ) : (
-            <div className="space-y-3">
+            <div className={`space-y-3 ${RECENT_NOTES_PANEL_MIN_HEIGHT_CLASS}`}>
               {notes.map((note) => (
                 <div
                   key={note.id}

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -127,20 +127,32 @@ export function UserProfileModal({
           </svg>
         </button>
 
-        <div className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        <div
+          className={`border-b border-gray-200 dark:border-gray-700 ${
+            bannerUrl
+              ? "relative overflow-hidden bg-gray-900"
+              : "bg-white dark:bg-gray-800"
+          }`}
+        >
           {bannerUrl && (
-            <div className="relative h-32 w-full overflow-hidden bg-gray-100 dark:bg-gray-700 sm:h-40">
-              <Image
-                src={bannerUrl}
-                alt={`${displayName} banner`}
-                fill
-                className="object-cover"
-                unoptimized
-              />
-            </div>
+            <>
+              <div className="absolute inset-0">
+                <Image
+                  src={bannerUrl}
+                  alt={`${displayName} banner`}
+                  fill
+                  className="object-cover"
+                  unoptimized
+                />
+              </div>
+              <div className="absolute inset-0 bg-gradient-to-b from-black/35 via-black/45 to-black/60" />
+              <div className="absolute inset-x-0 bottom-0 h-20 bg-white/10 backdrop-blur-[1px] dark:bg-black/10" />
+            </>
           )}
 
-          <div className="px-6 py-6 sm:px-8">
+          <div
+            className={`relative px-6 ${bannerUrl ? "py-5 text-white" : "py-6"} sm:px-8`}
+          >
             <div className="flex items-start gap-4 sm:gap-5">
               {avatarUrl ? (
                 <Image
@@ -148,7 +160,9 @@ export function UserProfileModal({
                   alt={displayName}
                   width={72}
                   height={72}
-                  className="h-16 w-16 rounded-full object-cover sm:h-[72px] sm:w-[72px]"
+                  className={`h-16 w-16 rounded-full object-cover sm:h-[72px] sm:w-[72px] ${
+                    bannerUrl ? "ring-2 ring-white/70" : ""
+                  }`}
                   unoptimized
                 />
               ) : (
@@ -159,24 +173,46 @@ export function UserProfileModal({
 
               <div className="min-w-0 flex-1 pr-10">
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                  <h2 className="truncate text-xl font-semibold text-gray-900 dark:text-gray-100 sm:text-2xl">
+                  <h2
+                    className={`truncate text-xl font-semibold sm:text-2xl ${
+                      bannerUrl ? "text-white" : "text-gray-900 dark:text-gray-100"
+                    }`}
+                  >
                     {displayName}
                   </h2>
                   {profile?.name && profile.name !== displayName && (
-                    <span className="truncate text-sm text-gray-500 dark:text-gray-400">@{profile.name}</span>
+                    <span
+                      className={`truncate text-sm ${
+                        bannerUrl ? "text-gray-200" : "text-gray-500 dark:text-gray-400"
+                      }`}
+                    >
+                      @{profile.name}
+                    </span>
                   )}
                 </div>
                 <div
-                  className="mt-1 break-all text-xs leading-5 text-gray-500 select-all dark:text-gray-400"
+                  className={`mt-1 break-all text-xs leading-5 select-all ${
+                    bannerUrl ? "text-gray-200" : "text-gray-500 dark:text-gray-400"
+                  }`}
                   title={npub}
                 >
                   {npub}
                 </div>
                 {profile?.nip05 && (
-                  <div className="mt-2 text-sm text-purple-600 dark:text-purple-400">{profile.nip05}</div>
+                  <div
+                    className={`mt-2 text-sm ${
+                      bannerUrl ? "text-purple-100" : "text-purple-600 dark:text-purple-400"
+                    }`}
+                  >
+                    {profile.nip05}
+                  </div>
                 )}
                 {profile?.about && (
-                  <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-gray-700 dark:text-gray-300">
+                  <p
+                    className={`mt-3 whitespace-pre-wrap text-sm leading-6 ${
+                      bannerUrl ? "text-gray-100" : "text-gray-700 dark:text-gray-300"
+                    }`}
+                  >
                     {profile.about}
                   </p>
                 )}

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -95,6 +95,7 @@ export function UserProfileModal({
 
   const displayName = resolveProfileDisplayName(pubkey, profile);
   const avatarUrl = profile?.picture;
+  const bannerUrl = profile?.banner;
   const npub = encodeNpub(pubkey);
 
   return createPortal(
@@ -126,46 +127,60 @@ export function UserProfileModal({
           </svg>
         </button>
 
-        <div className="border-b border-gray-200 bg-white px-6 py-6 dark:border-gray-700 dark:bg-gray-800 sm:px-8">
-          <div className="flex items-start gap-4 sm:gap-5">
-            {avatarUrl ? (
+        <div className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+          {bannerUrl && (
+            <div className="relative h-32 w-full overflow-hidden bg-gray-100 dark:bg-gray-700 sm:h-40">
               <Image
-                src={avatarUrl}
-                alt={displayName}
-                width={72}
-                height={72}
-                className="h-16 w-16 rounded-full object-cover sm:h-[72px] sm:w-[72px]"
+                src={bannerUrl}
+                alt={`${displayName} banner`}
+                fill
+                className="object-cover"
                 unoptimized
               />
-            ) : (
-              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-400 to-blue-500 sm:h-[72px] sm:w-[72px]">
-                <span className="text-xl font-bold text-white">{displayName.charAt(0).toUpperCase()}</span>
-              </div>
-            )}
+            </div>
+          )}
 
-            <div className="min-w-0 flex-1 pr-10">
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                <h2 className="truncate text-xl font-semibold text-gray-900 dark:text-gray-100 sm:text-2xl">
-                  {displayName}
-                </h2>
-                {profile?.name && profile.name !== displayName && (
-                  <span className="truncate text-sm text-gray-500 dark:text-gray-400">@{profile.name}</span>
+          <div className="px-6 py-6 sm:px-8">
+            <div className="flex items-start gap-4 sm:gap-5">
+              {avatarUrl ? (
+                <Image
+                  src={avatarUrl}
+                  alt={displayName}
+                  width={72}
+                  height={72}
+                  className="h-16 w-16 rounded-full object-cover sm:h-[72px] sm:w-[72px]"
+                  unoptimized
+                />
+              ) : (
+                <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-400 to-blue-500 sm:h-[72px] sm:w-[72px]">
+                  <span className="text-xl font-bold text-white">{displayName.charAt(0).toUpperCase()}</span>
+                </div>
+              )}
+
+              <div className="min-w-0 flex-1 pr-10">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <h2 className="truncate text-xl font-semibold text-gray-900 dark:text-gray-100 sm:text-2xl">
+                    {displayName}
+                  </h2>
+                  {profile?.name && profile.name !== displayName && (
+                    <span className="truncate text-sm text-gray-500 dark:text-gray-400">@{profile.name}</span>
+                  )}
+                </div>
+                <div
+                  className="mt-1 break-all text-xs leading-5 text-gray-500 select-all dark:text-gray-400"
+                  title={npub}
+                >
+                  {npub}
+                </div>
+                {profile?.nip05 && (
+                  <div className="mt-2 text-sm text-purple-600 dark:text-purple-400">{profile.nip05}</div>
+                )}
+                {profile?.about && (
+                  <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-gray-700 dark:text-gray-300">
+                    {profile.about}
+                  </p>
                 )}
               </div>
-              <div
-                className="mt-1 break-all text-xs leading-5 text-gray-500 select-all dark:text-gray-400"
-                title={npub}
-              >
-                {npub}
-              </div>
-              {profile?.nip05 && (
-                <div className="mt-2 text-sm text-purple-600 dark:text-purple-400">{profile.nip05}</div>
-              )}
-              {profile?.about && (
-                <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-gray-700 dark:text-gray-300">
-                  {profile.about}
-                </p>
-              )}
             </div>
           </div>
         </div>

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useEffect } from "react";
+import Image from "next/image";
+import { createPortal } from "react-dom";
+import { motion } from "framer-motion";
+import type { Event } from "nostr-tools/core";
+import type { EventCache } from "../hooks/useEventCache";
+import { useUserRecentNotes } from "../hooks/useUserRecentNotes";
+import type { NostrProfile } from "../lib/types";
+import { NoteCardContent, resolveProfileDisplayName, shortenPubkey } from "./NoteCardContent";
+
+interface UserProfileModalProps {
+  pubkey: string;
+  profile?: NostrProfile;
+  isOpen: boolean;
+  onClose: () => void;
+  fetchProfiles: (pubkeys: string[]) => void;
+  fetchUserRecentNotes: (pubkey: string) => Promise<Event[]>;
+  cache: EventCache;
+  profiles: Map<string, NostrProfile>;
+}
+
+export function UserProfileModal({
+  pubkey,
+  profile,
+  isOpen,
+  onClose,
+  fetchProfiles,
+  fetchUserRecentNotes,
+  cache,
+  profiles,
+}: UserProfileModalProps) {
+  const { notes, isLoading, error } = useUserRecentNotes({
+    pubkey: isOpen ? pubkey : null,
+    enabled: isOpen,
+    fetchUserRecentNotes,
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    fetchProfiles([pubkey]);
+  }, [isOpen, pubkey, fetchProfiles]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const displayName = resolveProfileDisplayName(pubkey, profile);
+  const avatarUrl = profile?.picture;
+
+  return createPortal(
+    <motion.div
+      key="user-profile-modal-overlay"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 px-4 py-6 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.96, y: 12 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.98, y: 8 }}
+        transition={{ duration: 0.2 }}
+        className="relative flex max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-4 z-10 rounded-full bg-white/90 p-2 text-gray-500 transition-colors hover:text-gray-900 dark:bg-gray-800/90 dark:text-gray-400 dark:hover:text-gray-100"
+          aria-label="閉じる"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        <div className="border-b border-gray-200 bg-white px-6 py-6 dark:border-gray-700 dark:bg-gray-800 sm:px-8">
+          <div className="flex items-start gap-4 sm:gap-5">
+            {avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                alt={displayName}
+                width={72}
+                height={72}
+                className="h-16 w-16 rounded-full object-cover sm:h-[72px] sm:w-[72px]"
+                unoptimized
+              />
+            ) : (
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-400 to-blue-500 sm:h-[72px] sm:w-[72px]">
+                <span className="text-xl font-bold text-white">{displayName.charAt(0).toUpperCase()}</span>
+              </div>
+            )}
+
+            <div className="min-w-0 flex-1 pr-10">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                <h2 className="truncate text-xl font-semibold text-gray-900 dark:text-gray-100 sm:text-2xl">
+                  {displayName}
+                </h2>
+                {profile?.name && profile.name !== displayName && (
+                  <span className="truncate text-sm text-gray-500 dark:text-gray-400">@{profile.name}</span>
+                )}
+              </div>
+              <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">{shortenPubkey(pubkey)}</div>
+              {profile?.nip05 && (
+                <div className="mt-2 text-sm text-purple-600 dark:text-purple-400">{profile.nip05}</div>
+              )}
+              {profile?.about && (
+                <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-gray-700 dark:text-gray-300">
+                  {profile.about}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5 sm:px-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              Recent notes
+            </h3>
+            <span className="text-xs text-gray-500 dark:text-gray-400">最新50件</span>
+          </div>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12 text-sm text-gray-500 dark:text-gray-400">
+              読み込み中...
+            </div>
+          ) : error ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+              {error}
+            </div>
+          ) : notes.length === 0 ? (
+            <div className="rounded-xl border border-gray-200 bg-white px-4 py-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
+              recent note はありません
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {notes.map((note) => (
+                <div
+                  key={note.id}
+                  className="rounded-xl border border-gray-200 bg-white px-4 py-4 dark:border-gray-700 dark:bg-gray-800"
+                >
+                  <NoteCardContent
+                    note={note}
+                    profile={profile}
+                    onHold={() => undefined}
+                    onRelease={() => undefined}
+                    cache={cache}
+                    profiles={profiles}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>,
+    document.body,
+  );
+}

--- a/apps/web/app/hooks/useNostrProfiles.ts
+++ b/apps/web/app/hooks/useNostrProfiles.ts
@@ -31,7 +31,16 @@ export function useNostrProfiles(
   /** プロフィールを追加・更新（kind:0イベントから） */
   const upsertProfile = useCallback((event: Event) => {
     try {
-      const data = JSON.parse(event.content) as NostrProfile;
+      const raw = JSON.parse(event.content) as Record<string, unknown>;
+      const data: NostrProfile = {
+        name: typeof raw.name === "string" ? raw.name : undefined,
+        display_name: typeof raw.display_name === "string" ? raw.display_name : undefined,
+        picture: typeof raw.picture === "string" ? raw.picture : undefined,
+        banner: typeof raw.banner === "string" ? raw.banner : undefined,
+        about: typeof raw.about === "string" ? raw.about : undefined,
+        nip05: typeof raw.nip05 === "string" ? raw.nip05 : undefined,
+      };
+
       setProfiles((prev) => {
         const next = new Map(prev);
         next.set(event.pubkey, data);

--- a/apps/web/app/hooks/useNostrRelay.ts
+++ b/apps/web/app/hooks/useNostrRelay.ts
@@ -12,7 +12,7 @@ import type { EventCache } from "./useEventCache";
 import { useCustomEmojis } from "./useCustomEmojis";
 import type { CustomEmoji, EmojiSet } from "./useCustomEmojis";
 import { SimplePool } from "nostr-tools/pool";
-import { CLIENT_TAG } from "../lib/constants";
+import { BOOTSTRAP_EOSE_TIMEOUT, CLIENT_TAG } from "../lib/constants";
 
 /** NIP-07拡張(window.nostr)の署名済みイベント型 */
 type SignedNostrEvent = NostrEvent & { id: string; sig: string };
@@ -28,6 +28,7 @@ interface UseNostrRelayResult {
   emojiSets: EmojiSet[];
   looseEmojis: CustomEmoji[];
   fetchProfiles: (pubkeys: string[]) => void;
+  fetchUserRecentNotes: (pubkey: string) => Promise<Event[]>;
   publishEvent: (event: NostrEvent) => Promise<void>;
   sendReaction: (targetEventId: string, targetPubkey: string, emoji: string, imageUrl?: string) => Promise<void>;
   sendRepost: (targetEventId: string, targetPubkey: string, originalEvent: NostrEvent) => Promise<void>;
@@ -46,7 +47,7 @@ export function useNostrRelay(
   publishedSlotMapRef: React.RefObject<Map<string, string>>,
 ): UseNostrRelayResult {
   const { pool, relayUrls, followPubkeys, status, setStatus } = useNostrConnection(pubkey);
-  const { profiles, upsertProfile, fetchProfiles, profilesRef } = useNostrProfiles(pool, relayUrls, followPubkeys);
+  const { profiles, fetchProfiles, profilesRef } = useNostrProfiles(pool, relayUrls, followPubkeys);
   const cache = useEventCache(pool, relayUrls, fetchProfiles);
   const { emojiSets, looseEmojis } = useCustomEmojis(pool, relayUrls, pubkey);
 
@@ -64,6 +65,29 @@ export function useNostrRelay(
 
   const { reactions, addReaction } = useNostrReactions(
     pool, relayUrls, notesRef, newNotesMinCreatedAtRef, initialEventIds,
+  );
+
+  const fetchUserRecentNotes = useCallback(
+    async (targetPubkey: string): Promise<Event[]> => {
+      if (!pool || relayUrls.length === 0) {
+        throw new Error("recent note を取得できませんでした。リレー接続を確認してください");
+      }
+
+      const events = await pool.querySync(
+        relayUrls,
+        { kinds: [1], authors: [targetPubkey], limit: 50 },
+        { maxWait: BOOTSTRAP_EOSE_TIMEOUT },
+      );
+
+      const recentNotes = events
+        .filter((event) => event.kind === 1)
+        .sort((a, b) => b.created_at - a.created_at)
+        .slice(0, 50);
+
+      cache.addEvents(recentNotes);
+      return recentNotes;
+    },
+    [pool, relayUrls, cache],
   );
 
   /** 署名済みイベントを全リレーにpublishする（1つ以上のリレーに成功すればOK） */
@@ -157,5 +181,5 @@ export function useNostrRelay(
     [publishEvent, relayUrls],
   );
 
-  return { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, fetchProfiles, publishEvent, sendReaction, sendRepost };
+  return { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, fetchProfiles, fetchUserRecentNotes, publishEvent, sendReaction, sendRepost };
 }

--- a/apps/web/app/hooks/useUserRecentNotes.ts
+++ b/apps/web/app/hooks/useUserRecentNotes.ts
@@ -103,8 +103,12 @@ export function useUserRecentNotes({
     };
   }, [enabled, pubkey, fetchUserRecentNotes]);
 
-  if (!enabled || !pubkey || state.requestedPubkey !== pubkey) {
+  if (!enabled || !pubkey) {
     return { notes: [], isLoading: false, error: null };
+  }
+
+  if (state.requestedPubkey !== pubkey) {
+    return { notes: [], isLoading: true, error: null };
   }
 
   return state;

--- a/apps/web/app/hooks/useUserRecentNotes.ts
+++ b/apps/web/app/hooks/useUserRecentNotes.ts
@@ -1,0 +1,111 @@
+import { useEffect, useReducer } from "react";
+import type { Event } from "nostr-tools/core";
+
+interface UseUserRecentNotesParams {
+  pubkey: string | null;
+  enabled: boolean;
+  fetchUserRecentNotes: (pubkey: string) => Promise<Event[]>;
+}
+
+interface UseUserRecentNotesResult {
+  notes: Event[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+interface UseUserRecentNotesState {
+  requestedPubkey: string | null;
+  notes: Event[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+type UseUserRecentNotesAction =
+  | { type: "start"; pubkey: string }
+  | { type: "success"; pubkey: string; notes: Event[] }
+  | { type: "error"; pubkey: string; error: string };
+
+function useUserRecentNotesReducer(
+  state: UseUserRecentNotesState,
+  action: UseUserRecentNotesAction,
+): UseUserRecentNotesState {
+  switch (action.type) {
+    case "start":
+      return {
+        requestedPubkey: action.pubkey,
+        notes: [],
+        isLoading: true,
+        error: null,
+      };
+    case "success":
+      if (state.requestedPubkey !== action.pubkey) {
+        return state;
+      }
+
+      return {
+        requestedPubkey: action.pubkey,
+        notes: action.notes,
+        isLoading: false,
+        error: null,
+      };
+    case "error":
+      if (state.requestedPubkey !== action.pubkey) {
+        return state;
+      }
+
+      return {
+        requestedPubkey: action.pubkey,
+        notes: [],
+        isLoading: false,
+        error: action.error,
+      };
+    default:
+      return state;
+  }
+}
+
+export function useUserRecentNotes({
+  pubkey,
+  enabled,
+  fetchUserRecentNotes,
+}: UseUserRecentNotesParams): UseUserRecentNotesResult {
+  const [state, dispatch] = useReducer(useUserRecentNotesReducer, {
+    requestedPubkey: null,
+    notes: [],
+    isLoading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!enabled || !pubkey) {
+      return;
+    }
+
+    let cancelled = false;
+    dispatch({ type: "start", pubkey });
+
+    void fetchUserRecentNotes(pubkey)
+      .then((events) => {
+        if (cancelled) return;
+        dispatch({ type: "success", pubkey, notes: events });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        dispatch({
+          type: "error",
+          pubkey,
+          error: err instanceof Error ? err.message : "ノートの取得に失敗しました",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, pubkey, fetchUserRecentNotes]);
+
+  if (!enabled || !pubkey || state.requestedPubkey !== pubkey) {
+    return { notes: [], isLoading: false, error: null };
+  }
+
+  return state;
+}

--- a/apps/web/app/lib/nip19.ts
+++ b/apps/web/app/lib/nip19.ts
@@ -126,6 +126,16 @@ export function encodeNevent(eventId: string, pubkey?: string): string {
 }
 
 /**
+ * pubkey を npub1... 文字列にエンコードする
+ *
+ * @param pubkey hex形式のpubkey
+ * @returns bech32エンコードされた npub 文字列
+ */
+export function encodeNpub(pubkey: string): string {
+  return nip19.npubEncode(pubkey);
+}
+
+/**
  * nostr: URI をパースしてデコード結果を返す
  *
  * 対応プレフィックス: nostr:nevent1..., nostr:note1..., nostr:naddr1...

--- a/apps/web/app/lib/types.ts
+++ b/apps/web/app/lib/types.ts
@@ -65,6 +65,7 @@ export interface NostrProfile {
   name?: string;
   display_name?: string;
   picture?: string;
+  banner?: string;
   about?: string;
   nip05?: string;
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   const { pubkey, npub, nip07Available, autoLoading, login, logout } = useAuth();
   // eventId → slotId のマッピング（publish時に登録し、リレー到着時に参照する）
   const publishedSlotMapRef = useRef<Map<string, string>>(new Map());
-  const { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, fetchProfiles, publishEvent, sendReaction, sendRepost } = useNostrRelay(pubkey, publishedSlotMapRef);
+  const { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, fetchProfiles, fetchUserRecentNotes, publishEvent, sendReaction, sendRepost } = useNostrRelay(pubkey, publishedSlotMapRef);
   const { filteredNotes, threadCards, isProcessing } = useThreadCards(notes, pubkey, relayUrls, pool, status, cache, publishedSlotMapRef);
   const { recentEmojis, addEmoji } = useRecentEmojis(pool, relayUrls, pubkey);
 
@@ -45,6 +45,7 @@ export default function Home() {
         emojiSets={emojiSets}
         looseEmojis={looseEmojis}
         fetchProfiles={fetchProfiles}
+        fetchUserRecentNotes={fetchUserRecentNotes}
       />
     );
   }


### PR DESCRIPTION
## Summary
- extract shared note card presentation for reusable read-only note rendering
- add a user profile modal opened from note avatars/display names
- fetch and show recent kind:1 notes plus explicit profile fetch for non-follow users

## Testing
- npm run lint
- npm run build