### PR TITLE
feat: add follow button to user profile modal

### DIFF
--- a/apps/web/app/components/LiveCanvas.tsx
+++ b/apps/web/app/components/LiveCanvas.tsx
@@ -56,13 +56,16 @@ interface LiveCanvasProps {
   looseEmojis: CustomEmoji[];
   fetchProfiles: (pubkeys: string[]) => void;
   fetchUserRecentNotes: (pubkey: string) => Promise<Event[]>;
+  isFollowing: (targetPubkey: string) => boolean;
+  follow: (targetPubkey: string) => Promise<void>;
+  unfollow: (targetPubkey: string) => Promise<void>;
 }
 
 function calcColumnCount(width: number): number {
   return Math.max(1, Math.floor(width / COLUMN_WIDTH));
 }
 
-export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis, emojiSets, looseEmojis, fetchProfiles, fetchUserRecentNotes }: LiveCanvasProps) {
+export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis, emojiSets, looseEmojis, fetchProfiles, fetchUserRecentNotes, isFollowing, follow, unfollow }: LiveCanvasProps) {
   const [columnCount, setColumnCount] = useState(1);
   const [holdSet, setHoldSet] = useState<Set<string>>(() => new Set());
   const [profileModalPubkey, setProfileModalPubkey] = useState<string | null>(null);
@@ -595,6 +598,9 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
           fetchUserRecentNotes={fetchUserRecentNotes}
           cache={cache}
           profiles={profiles}
+          isFollowing={isFollowing(profileModalPubkey)}
+          follow={follow}
+          unfollow={unfollow}
         />
       )}
     </div>

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -150,7 +150,7 @@ export function UserProfileModal({
         <button
           type="button"
           onClick={onClose}
-          className="absolute right-4 top-4 z-10 rounded-full bg-white/90 p-2 text-gray-500 transition-colors hover:text-gray-900 dark:bg-gray-800/90 dark:text-gray-400 dark:hover:text-gray-100"
+          className="absolute right-4 top-4 z-20 cursor-pointer rounded-full bg-white/90 p-2 text-gray-500 transition-colors hover:text-gray-900 dark:bg-gray-800/90 dark:text-gray-400 dark:hover:text-gray-100"
           aria-label="閉じる"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -256,7 +256,7 @@ export function UserProfileModal({
                   type="button"
                   onClick={handleFollowClick}
                   disabled={isSubmittingFollow}
-                  className={`inline-flex min-w-[112px] items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-70 ${
+                  className={`inline-flex min-w-[112px] cursor-pointer items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-70 ${
                     isFollowing
                       ? bannerUrl
                         ? "border border-white/30 bg-white/10 text-white hover:bg-white/15"

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -150,7 +150,7 @@ export function UserProfileModal({
         <button
           type="button"
           onClick={onClose}
-          className="absolute right-4 top-4 z-20 cursor-pointer rounded-full bg-white/90 p-2 text-gray-500 transition-colors hover:text-gray-900 dark:bg-gray-800/90 dark:text-gray-400 dark:hover:text-gray-100"
+          className="absolute right-4 top-5 z-20 cursor-pointer rounded-full bg-white/90 p-2 text-gray-500 transition-colors hover:text-gray-900 dark:bg-gray-800/90 dark:text-gray-400 dark:hover:text-gray-100"
           aria-label="閉じる"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import { createPortal } from "react-dom";
 import { motion } from "framer-motion";
@@ -20,6 +20,9 @@ interface UserProfileModalProps {
   fetchUserRecentNotes: (pubkey: string) => Promise<Event[]>;
   cache: EventCache;
   profiles: Map<string, NostrProfile>;
+  isFollowing: boolean;
+  follow: (targetPubkey: string) => Promise<void>;
+  unfollow: (targetPubkey: string) => Promise<void>;
 }
 
 const RECENT_NOTES_PANEL_MIN_HEIGHT_CLASS = "min-h-[420px]";
@@ -61,12 +64,17 @@ export function UserProfileModal({
   fetchUserRecentNotes,
   cache,
   profiles,
+  isFollowing,
+  follow,
+  unfollow,
 }: UserProfileModalProps) {
   const { notes, isLoading, error } = useUserRecentNotes({
     pubkey: isOpen ? pubkey : null,
     enabled: isOpen,
     fetchUserRecentNotes,
   });
+  const [isSubmittingFollow, setIsSubmittingFollow] = useState(false);
+  const [followError, setFollowError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -91,12 +99,35 @@ export function UserProfileModal({
     };
   }, [isOpen, onClose]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    setIsSubmittingFollow(false);
+    setFollowError(null);
+  }, [isOpen, pubkey]);
+
   if (!isOpen) return null;
 
   const displayName = resolveProfileDisplayName(pubkey, profile);
   const avatarUrl = profile?.picture;
   const bannerUrl = profile?.banner;
   const npub = encodeNpub(pubkey);
+
+  const handleFollowClick = async () => {
+    setIsSubmittingFollow(true);
+    setFollowError(null);
+
+    try {
+      if (isFollowing) {
+        await unfollow(pubkey);
+      } else {
+        await follow(pubkey);
+      }
+    } catch (err) {
+      setFollowError(err instanceof Error ? err.message : "フォロー状態を更新できませんでした");
+    } finally {
+      setIsSubmittingFollow(false);
+    }
+  };
 
   return createPortal(
     <motion.div
@@ -153,67 +184,97 @@ export function UserProfileModal({
           <div
             className={`relative px-6 ${bannerUrl ? "py-5 text-white" : "py-6"} sm:px-8`}
           >
-            <div className="flex items-start gap-4 sm:gap-5">
-              {avatarUrl ? (
-                <Image
-                  src={avatarUrl}
-                  alt={displayName}
-                  width={72}
-                  height={72}
-                  className={`h-16 w-16 rounded-full object-cover sm:h-[72px] sm:w-[72px] ${
-                    bannerUrl ? "ring-2 ring-white/70" : ""
-                  }`}
-                  unoptimized
-                />
-              ) : (
-                <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-400 to-blue-500 sm:h-[72px] sm:w-[72px]">
-                  <span className="text-xl font-bold text-white">{displayName.charAt(0).toUpperCase()}</span>
-                </div>
-              )}
-
-              <div className="min-w-0 flex-1 pr-10">
-                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                  <h2
-                    className={`truncate text-xl font-semibold sm:text-2xl ${
-                      bannerUrl ? "text-white" : "text-gray-900 dark:text-gray-100"
+            <div className="flex items-start justify-between gap-4 sm:gap-5">
+              <div className="flex min-w-0 flex-1 items-start gap-4 sm:gap-5">
+                {avatarUrl ? (
+                  <Image
+                    src={avatarUrl}
+                    alt={displayName}
+                    width={72}
+                    height={72}
+                    className={`h-16 w-16 rounded-full object-cover sm:h-[72px] sm:w-[72px] ${
+                      bannerUrl ? "ring-2 ring-white/70" : ""
                     }`}
-                  >
-                    {displayName}
-                  </h2>
-                  {profile?.name && profile.name !== displayName && (
-                    <span
-                      className={`truncate text-sm ${
-                        bannerUrl ? "text-gray-200" : "text-gray-500 dark:text-gray-400"
-                      }`}
-                    >
-                      @{profile.name}
-                    </span>
-                  )}
-                </div>
-                <div
-                  className={`mt-1 break-all text-xs leading-5 select-all ${
-                    bannerUrl ? "text-gray-200" : "text-gray-500 dark:text-gray-400"
-                  }`}
-                  title={npub}
-                >
-                  {npub}
-                </div>
-                {profile?.nip05 && (
-                  <div
-                    className={`mt-2 text-sm ${
-                      bannerUrl ? "text-purple-100" : "text-purple-600 dark:text-purple-400"
-                    }`}
-                  >
-                    {profile.nip05}
+                    unoptimized
+                  />
+                ) : (
+                  <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-400 to-blue-500 sm:h-[72px] sm:w-[72px]">
+                    <span className="text-xl font-bold text-white">{displayName.charAt(0).toUpperCase()}</span>
                   </div>
                 )}
-                {profile?.about && (
+
+                <div className="min-w-0 flex-1 pr-2 sm:pr-6">
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                    <h2
+                      className={`truncate text-xl font-semibold sm:text-2xl ${
+                        bannerUrl ? "text-white" : "text-gray-900 dark:text-gray-100"
+                      }`}
+                    >
+                      {displayName}
+                    </h2>
+                    {profile?.name && profile.name !== displayName && (
+                      <span
+                        className={`truncate text-sm ${
+                          bannerUrl ? "text-gray-200" : "text-gray-500 dark:text-gray-400"
+                        }`}
+                      >
+                        @{profile.name}
+                      </span>
+                    )}
+                  </div>
+                  <div
+                    className={`mt-1 break-all text-xs leading-5 select-all ${
+                      bannerUrl ? "text-gray-200" : "text-gray-500 dark:text-gray-400"
+                    }`}
+                    title={npub}
+                  >
+                    {npub}
+                  </div>
+                  {profile?.nip05 && (
+                    <div
+                      className={`mt-2 text-sm ${
+                        bannerUrl ? "text-purple-100" : "text-purple-600 dark:text-purple-400"
+                      }`}
+                    >
+                      {profile.nip05}
+                    </div>
+                  )}
+                  {profile?.about && (
+                    <p
+                      className={`mt-3 whitespace-pre-wrap text-sm leading-6 ${
+                        bannerUrl ? "text-gray-100" : "text-gray-700 dark:text-gray-300"
+                      }`}
+                    >
+                      {profile.about}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div className="relative z-10 mt-10 flex shrink-0 flex-col items-end gap-2 sm:mt-0 sm:pr-12">
+                <button
+                  type="button"
+                  onClick={handleFollowClick}
+                  disabled={isSubmittingFollow}
+                  className={`inline-flex min-w-[112px] items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-70 ${
+                    isFollowing
+                      ? bannerUrl
+                        ? "border border-white/30 bg-white/10 text-white hover:bg-white/15"
+                        : "border border-gray-300 bg-white text-gray-900 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+                      : bannerUrl
+                        ? "bg-purple-500 text-white hover:bg-purple-400"
+                        : "bg-purple-600 text-white hover:bg-purple-700 dark:bg-purple-500 dark:hover:bg-purple-400"
+                  }`}
+                >
+                  {isSubmittingFollow ? "Updating..." : isFollowing ? "Following" : "Follow"}
+                </button>
+                {followError && (
                   <p
-                    className={`mt-3 whitespace-pre-wrap text-sm leading-6 ${
-                      bannerUrl ? "text-gray-100" : "text-gray-700 dark:text-gray-300"
+                    className={`max-w-[220px] text-right text-xs ${
+                      bannerUrl ? "text-red-100" : "text-red-600 dark:text-red-400"
                     }`}
                   >
-                    {profile.about}
+                    {followError}
                   </p>
                 )}
               </div>

--- a/apps/web/app/hooks/useNostrConnection.ts
+++ b/apps/web/app/hooks/useNostrConnection.ts
@@ -1,14 +1,18 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { SimplePool } from "nostr-tools/pool";
 import type { Event } from "nostr-tools/core";
 import type { Filter } from "nostr-tools/filter";
 import {
   BOOTSTRAP_RELAYS,
   BOOTSTRAP_EOSE_TIMEOUT,
+  CLIENT_TAG,
   MAX_WAIT_FOR_CONNECTION,
 } from "../lib/constants";
+import type { NostrEvent } from "../types/nostr";
 
 export type ConnectionStatus = "connecting" | "loading" | "connected" | "error";
+
+type FollowAction = "follow" | "unfollow";
 
 export interface UseNostrConnectionResult {
   pool: SimplePool | null;
@@ -16,6 +20,7 @@ export interface UseNostrConnectionResult {
   followPubkeys: string[];
   status: ConnectionStatus;
   setStatus: (status: ConnectionStatus) => void;
+  updateFollowList: (targetPubkey: string, action: FollowAction) => Promise<string[]>;
 }
 
 /**
@@ -27,6 +32,89 @@ export function useNostrConnection(pubkey: string | null): UseNostrConnectionRes
   const [followPubkeys, setFollowPubkeys] = useState<string[]>([]);
   const [pool, setPool] = useState<SimplePool | null>(null);
   const poolRef = useRef<SimplePool | null>(null);
+  const relayUrlsRef = useRef<string[]>([]);
+
+  useEffect(() => {
+    relayUrlsRef.current = relayUrls;
+  }, [relayUrls]);
+
+  const fetchLatestContactEvent = useCallback(async (): Promise<Event | null> => {
+    const currentPool = poolRef.current;
+    if (!currentPool || !pubkey) {
+      throw new Error("kind:3 を取得できませんでした。接続を確認してください");
+    }
+
+    const queryRelays = relayUrlsRef.current.length > 0 ? relayUrlsRef.current : BOOTSTRAP_RELAYS;
+    const contactEvents = await currentPool.querySync(
+      queryRelays,
+      { authors: [pubkey], kinds: [3], limit: 1 } as Filter,
+      { maxWait: BOOTSTRAP_EOSE_TIMEOUT },
+    );
+
+    return contactEvents.reduce<Event | null>(
+      (latest, event) => (!latest || event.created_at > latest.created_at ? event : latest),
+      null,
+    );
+  }, [pubkey]);
+
+  const updateFollowList = useCallback(async (targetPubkey: string, action: FollowAction): Promise<string[]> => {
+    if (!targetPubkey) {
+      throw new Error("対象ユーザーが不正です");
+    }
+
+    const currentPool = poolRef.current;
+    const currentRelays = relayUrlsRef.current.length > 0 ? relayUrlsRef.current : BOOTSTRAP_RELAYS;
+    if (!currentPool || currentRelays.length === 0 || !pubkey) {
+      throw new Error("フォロー状態を更新できませんでした。接続を確認してください");
+    }
+
+    const nostrExt = window.nostr;
+    if (!nostrExt) {
+      throw new Error("NIP-07拡張（window.nostr）が見つかりません");
+    }
+
+    const latestContactEvent = await fetchLatestContactEvent();
+    const baseTags = latestContactEvent?.tags ?? [CLIENT_TAG];
+    const nonPTags = baseTags.filter((tag) => tag[0] !== "p");
+    const existingPTags = baseTags.filter((tag) => tag[0] === "p" && tag[1]);
+
+    const pTagMap = new Map<string, string[]>();
+    for (const tag of existingPTags) {
+      const followedPubkey = tag[1];
+      if (!followedPubkey || pTagMap.has(followedPubkey)) continue;
+      pTagMap.set(followedPubkey, tag);
+    }
+
+    if (action === "follow") {
+      if (!pTagMap.has(targetPubkey)) {
+        pTagMap.set(targetPubkey, ["p", targetPubkey]);
+      }
+    } else {
+      pTagMap.delete(targetPubkey);
+    }
+
+    const nextFollowPubkeys = Array.from(pTagMap.keys());
+    const nextTags = [...nonPTags, ...Array.from(pTagMap.values())];
+
+    const unsignedEvent: NostrEvent = {
+      kind: 3,
+      content: latestContactEvent?.content ?? "",
+      tags: nextTags,
+      created_at: Math.floor(Date.now() / 1000),
+    };
+
+    const signedEvent = await nostrExt.signEvent(unsignedEvent);
+    const results = await Promise.allSettled(
+      currentPool.publish(currentRelays, signedEvent as Event),
+    );
+    const hasSuccess = results.some((result) => result.status === "fulfilled");
+    if (!hasSuccess) {
+      throw new Error("kind:3 の送信に失敗しました");
+    }
+
+    setFollowPubkeys(nextFollowPubkeys);
+    return nextFollowPubkeys;
+  }, [fetchLatestContactEvent, pubkey]);
 
   useEffect(() => {
     if (!pubkey) {
@@ -117,5 +205,5 @@ export function useNostrConnection(pubkey: string | null): UseNostrConnectionRes
     };
   }, [pubkey]);
 
-  return { pool, relayUrls, followPubkeys, status, setStatus };
+  return { pool, relayUrls, followPubkeys, status, setStatus, updateFollowList };
 }

--- a/apps/web/app/hooks/useNostrNotes.ts
+++ b/apps/web/app/hooks/useNostrNotes.ts
@@ -4,7 +4,6 @@ import type { Event } from "nostr-tools/core";
 import type { Filter } from "nostr-tools/filter";
 import type { SubCloser } from "nostr-tools/abstract-pool";
 import {
-  BOOTSTRAP_EOSE_TIMEOUT,
   MAX_NOTES,
   INITIAL_NOTES_LIMIT,
 } from "../lib/constants";
@@ -138,6 +137,8 @@ export function useNostrNotes(
   // kind:1/6 subscribe
   useEffect(() => {
     if (!pool || relayUrls.length === 0 || followPubkeys.length === 0 || !pubkey) return;
+
+    setStatus("loading");
 
     let cancelled = false;
 
@@ -339,7 +340,6 @@ export function useNostrNotes(
       } catch {
         // 既に閉じている場合は無視
       }
-      setNotes([]);
     };
   }, [pool, relayUrls, followPubkeys, pubkey, publishedSlotMapRef, addNote, processOriginalNote, profilesRef, setStatus, cache]);
 

--- a/apps/web/app/hooks/useNostrRelay.ts
+++ b/apps/web/app/hooks/useNostrRelay.ts
@@ -32,6 +32,9 @@ interface UseNostrRelayResult {
   publishEvent: (event: NostrEvent) => Promise<void>;
   sendReaction: (targetEventId: string, targetPubkey: string, emoji: string, imageUrl?: string) => Promise<void>;
   sendRepost: (targetEventId: string, targetPubkey: string, originalEvent: NostrEvent) => Promise<void>;
+  isFollowing: (targetPubkey: string) => boolean;
+  follow: (targetPubkey: string) => Promise<void>;
+  unfollow: (targetPubkey: string) => Promise<void>;
 }
 
 /**
@@ -46,7 +49,7 @@ export function useNostrRelay(
   pubkey: string | null,
   publishedSlotMapRef: React.RefObject<Map<string, string>>,
 ): UseNostrRelayResult {
-  const { pool, relayUrls, followPubkeys, status, setStatus } = useNostrConnection(pubkey);
+  const { pool, relayUrls, followPubkeys, status, setStatus, updateFollowList } = useNostrConnection(pubkey);
   const { profiles, fetchProfiles, profilesRef } = useNostrProfiles(pool, relayUrls, followPubkeys);
   const cache = useEventCache(pool, relayUrls, fetchProfiles);
   const { emojiSets, looseEmojis } = useCustomEmojis(pool, relayUrls, pubkey);
@@ -105,6 +108,25 @@ export function useNostrRelay(
       }
     },
     [pool, relayUrls],
+  );
+
+  const isFollowing = useCallback(
+    (targetPubkey: string) => followPubkeys.includes(targetPubkey),
+    [followPubkeys],
+  );
+
+  const follow = useCallback(
+    async (targetPubkey: string) => {
+      await updateFollowList(targetPubkey, "follow");
+    },
+    [updateFollowList],
+  );
+
+  const unfollow = useCallback(
+    async (targetPubkey: string) => {
+      await updateFollowList(targetPubkey, "unfollow");
+    },
+    [updateFollowList],
   );
 
   /** NIP-25準拠のリアクションイベントを構築・署名・送信し、楽観的にUIを更新する */
@@ -181,5 +203,23 @@ export function useNostrRelay(
     [publishEvent, relayUrls],
   );
 
-  return { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, fetchProfiles, fetchUserRecentNotes, publishEvent, sendReaction, sendRepost };
+  return {
+    notes,
+    profiles,
+    reactions,
+    status,
+    relayUrls,
+    pool,
+    cache,
+    emojiSets,
+    looseEmojis,
+    fetchProfiles,
+    fetchUserRecentNotes,
+    publishEvent,
+    sendReaction,
+    sendRepost,
+    isFollowing,
+    follow,
+    unfollow,
+  };
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,7 +11,25 @@ export default function Home() {
   const { pubkey, npub, nip07Available, autoLoading, login, logout } = useAuth();
   // eventId → slotId のマッピング（publish時に登録し、リレー到着時に参照する）
   const publishedSlotMapRef = useRef<Map<string, string>>(new Map());
-  const { notes, profiles, reactions, status, relayUrls, pool, cache, emojiSets, looseEmojis, fetchProfiles, fetchUserRecentNotes, publishEvent, sendReaction, sendRepost } = useNostrRelay(pubkey, publishedSlotMapRef);
+  const {
+    notes,
+    profiles,
+    reactions,
+    status,
+    relayUrls,
+    pool,
+    cache,
+    emojiSets,
+    looseEmojis,
+    fetchProfiles,
+    fetchUserRecentNotes,
+    publishEvent,
+    sendReaction,
+    sendRepost,
+    isFollowing,
+    follow,
+    unfollow,
+  } = useNostrRelay(pubkey, publishedSlotMapRef);
   const { filteredNotes, threadCards, isProcessing } = useThreadCards(notes, pubkey, relayUrls, pool, status, cache, publishedSlotMapRef);
   const { recentEmojis, addEmoji } = useRecentEmojis(pool, relayUrls, pubkey);
 
@@ -46,6 +64,9 @@ export default function Home() {
         looseEmojis={looseEmojis}
         fetchProfiles={fetchProfiles}
         fetchUserRecentNotes={fetchUserRecentNotes}
+        isFollowing={isFollowing}
+        follow={follow}
+        unfollow={unfollow}
       />
     );
   }


### PR DESCRIPTION
## Summary
- add Follow/Following actions to the user profile modal and wire them through LiveCanvas/page
- update kind:3 follow publishing to refetch the latest contact list and rewrite only p tags before publishing
- keep existing notes visible while follow subscriptions reload so unfollow does not blank the feed immediately

## Testing
- npm run lint
- npm run test
- npm run build