### PR TITLE
OGPリンクプレビューを追加

### DIFF
--- a/apps/web/app/api/link-preview/route.ts
+++ b/apps/web/app/api/link-preview/route.ts
@@ -11,7 +11,12 @@ const TIMEOUT_MS = 3000;
 const MAX_HTML_BYTES = 256 * 1024;
 const ALLOWED_CONTENT_TYPES = ["text/html", "application/xhtml+xml"];
 
-type LookupCallback = (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
+type LookupResult = { address: string; family: number };
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address: string | LookupResult[],
+  family?: number,
+) => void;
 
 interface LinkPreviewData {
   url: string;
@@ -138,9 +143,17 @@ async function validateUrl(url: URL): Promise<void> {
   }
 }
 
-function publicLookup(hostname: string, _options: unknown, callback: LookupCallback): void {
+function publicLookup(hostname: string, options: { all?: boolean } | undefined, callback: LookupCallback): void {
   void resolvePublicAddresses(hostname)
-    .then(([entry]) => callback(null, entry.address, entry.family))
+    .then((entries) => {
+      if (options?.all) {
+        callback(null, entries);
+        return;
+      }
+
+      const [entry] = entries;
+      callback(null, entry.address, entry.family);
+    })
     .catch((error: NodeJS.ErrnoException) => callback(error, "", 0));
 }
 

--- a/apps/web/app/api/link-preview/route.ts
+++ b/apps/web/app/api/link-preview/route.ts
@@ -186,6 +186,34 @@ function isAllowedContentType(value: string | undefined): boolean {
   return ALLOWED_CONTENT_TYPES.includes(mime);
 }
 
+function charsetFromContentType(value: string | undefined): string | undefined {
+  const match = value?.match(/(?:^|;)\s*charset\s*=\s*["']?([^;"']+)/i);
+  return match?.[1]?.trim().toLowerCase();
+}
+
+function charsetFromMeta(buffer: Buffer): string | undefined {
+  const head = buffer.toString("latin1", 0, Math.min(buffer.byteLength, 4096));
+  const match = head.match(/<meta\b[^>]+charset\s*=\s*["']?([^\s"'>;]+)/i);
+  return match?.[1]?.trim().toLowerCase();
+}
+
+function normalizeCharset(charset: string | undefined): string {
+  if (!charset) return "utf-8";
+  if (charset === "shift_jis" || charset === "shift-jis" || charset === "x-sjis" || charset === "sjis") {
+    return "shift_jis";
+  }
+  return charset;
+}
+
+function decodeHtml(buffer: Buffer, contentType: string | undefined): string {
+  const charset = normalizeCharset(charsetFromContentType(contentType) ?? charsetFromMeta(buffer));
+  try {
+    return new TextDecoder(charset, { fatal: false }).decode(buffer);
+  } catch {
+    return new TextDecoder("utf-8", { fatal: false }).decode(buffer);
+  }
+}
+
 async function fetchHtml(inputUrl: URL): Promise<{ html: string; finalUrl: URL }> {
   let currentUrl = inputUrl;
 
@@ -222,8 +250,6 @@ async function fetchHtml(inputUrl: URL): Promise<{ html: string; finalUrl: URL }
 
       const chunks: Uint8Array[] = [];
       let received = 0;
-      let html = "";
-      const decoder = new TextDecoder("utf-8", { fatal: false });
 
       for await (const chunk of response) {
         const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
@@ -234,15 +260,15 @@ async function fetchHtml(inputUrl: URL): Promise<{ html: string; finalUrl: URL }
         }
         chunks.push(buffer);
 
-        html = decoder.decode(Buffer.concat(chunks), { stream: true });
-        if (/<\/head\s*>/i.test(html)) {
+        const currentBuffer = Buffer.concat(chunks);
+        if (/<\/head\s*>/i.test(currentBuffer.toString("latin1"))) {
           response.destroy();
-          return { html, finalUrl: currentUrl };
+          return { html: decodeHtml(currentBuffer, contentType), finalUrl: currentUrl };
         }
       }
 
-      html += decoder.decode();
-      return { html, finalUrl: currentUrl };
+      const htmlBuffer = Buffer.concat(chunks);
+      return { html: decodeHtml(htmlBuffer, contentType), finalUrl: currentUrl };
     } finally {
       clearTimeout(timeout);
     }

--- a/apps/web/app/api/link-preview/route.ts
+++ b/apps/web/app/api/link-preview/route.ts
@@ -8,7 +8,7 @@ export const runtime = "nodejs";
 
 const MAX_REDIRECTS = 4;
 const TIMEOUT_MS = 3000;
-const MAX_HTML_BYTES = 256 * 1024;
+const MAX_HTML_BYTES = 1024 * 1024;
 const ALLOWED_CONTENT_TYPES = ["text/html", "application/xhtml+xml"];
 
 type LookupResult = { address: string; family: number };
@@ -222,6 +222,8 @@ async function fetchHtml(inputUrl: URL): Promise<{ html: string; finalUrl: URL }
 
       const chunks: Uint8Array[] = [];
       let received = 0;
+      let html = "";
+      const decoder = new TextDecoder("utf-8", { fatal: false });
 
       for await (const chunk of response) {
         const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
@@ -231,9 +233,15 @@ async function fetchHtml(inputUrl: URL): Promise<{ html: string; finalUrl: URL }
           throw new Error("html_too_large");
         }
         chunks.push(buffer);
+
+        html = decoder.decode(Buffer.concat(chunks), { stream: true });
+        if (/<\/head\s*>/i.test(html)) {
+          response.destroy();
+          return { html, finalUrl: currentUrl };
+        }
       }
 
-      const html = new TextDecoder("utf-8", { fatal: false }).decode(Buffer.concat(chunks));
+      html += decoder.decode();
       return { html, finalUrl: currentUrl };
     } finally {
       clearTimeout(timeout);

--- a/apps/web/app/api/link-preview/route.ts
+++ b/apps/web/app/api/link-preview/route.ts
@@ -1,0 +1,348 @@
+import { lookup } from "node:dns/promises";
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const MAX_REDIRECTS = 4;
+const TIMEOUT_MS = 3000;
+const MAX_HTML_BYTES = 256 * 1024;
+const ALLOWED_CONTENT_TYPES = ["text/html", "application/xhtml+xml"];
+
+type LookupCallback = (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
+
+interface LinkPreviewData {
+  url: string;
+  domain: string;
+  title: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+}
+
+function isPrivateIPv4(address: string): boolean {
+  const parts = address.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return true;
+  }
+
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    a >= 224
+  );
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[|\]$/g, "");
+}
+
+function parseIPv4Bytes(address: string): number[] | null {
+  const parts = address.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return null;
+  }
+  return parts;
+}
+
+function parseIPv6Bytes(address: string): number[] | null {
+  const withoutZone = normalizeHostname(address).split("%")[0];
+  const ipv4Match = withoutZone.match(/(\d+\.\d+\.\d+\.\d+)$/);
+  const ipv4Bytes = ipv4Match ? parseIPv4Bytes(ipv4Match[1]) : null;
+  if (ipv4Match && !ipv4Bytes) return null;
+
+  const normalized = ipv4Bytes
+    ? withoutZone.replace(
+        ipv4Match![1],
+        `${((ipv4Bytes[0] << 8) | ipv4Bytes[1]).toString(16)}:${((ipv4Bytes[2] << 8) | ipv4Bytes[3]).toString(16)}`,
+      )
+    : withoutZone;
+  const halves = normalized.split("::");
+  if (halves.length > 2) return null;
+
+  const left = halves[0] ? halves[0].split(":") : [];
+  const right = halves[1] ? halves[1].split(":") : [];
+  const fill = halves.length === 2 ? 8 - left.length - right.length : 0;
+  const groups = [...left, ...Array(Math.max(fill, 0)).fill("0"), ...right];
+  if (groups.length !== 8 || groups.some((group) => !/^[0-9a-f]{1,4}$/i.test(group))) {
+    return null;
+  }
+
+  return groups.flatMap((group) => {
+    const value = Number.parseInt(group, 16);
+    return [value >> 8, value & 0xff];
+  });
+}
+
+function isPrivateIPv6(address: string): boolean {
+  const bytes = parseIPv6Bytes(address);
+  if (!bytes) return true;
+
+  const isUnspecified = bytes.every((byte) => byte === 0);
+  const isLoopback = bytes.slice(0, 15).every((byte) => byte === 0) && bytes[15] === 1;
+  const isIPv4Mapped = bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff;
+  const isIPv4Compatible = bytes.slice(0, 12).every((byte) => byte === 0) && bytes.slice(12).some((byte) => byte !== 0);
+  const mappedIPv4 = isIPv4Mapped || isIPv4Compatible ? bytes.slice(12).join(".") : null;
+
+  return (
+    isUnspecified ||
+    isLoopback ||
+    ((bytes[0] & 0xfe) === 0xfc) ||
+    (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) ||
+    bytes[0] === 0xff ||
+    (mappedIPv4 ? isPrivateIPv4(mappedIPv4) : false)
+  );
+}
+
+function isBlockedAddress(address: string): boolean {
+  const normalized = normalizeHostname(address);
+  const family = net.isIP(normalized);
+  if (family === 4) return isPrivateIPv4(normalized);
+  if (family === 6) return isPrivateIPv6(normalized);
+  return true;
+}
+
+async function resolvePublicAddresses(hostname: string): Promise<{ address: string; family: number }[]> {
+  const addresses = await lookup(hostname, { all: true, verbatim: false });
+  if (addresses.length === 0 || addresses.some((entry) => isBlockedAddress(entry.address))) {
+    throw new Error("blocked_resolved_ip");
+  }
+  return addresses;
+}
+
+async function validateUrl(url: URL): Promise<void> {
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("unsupported_protocol");
+  }
+
+  const hostname = normalizeHostname(url.hostname);
+  if (!hostname || hostname === "localhost" || hostname.endsWith(".localhost")) {
+    throw new Error("blocked_hostname");
+  }
+
+  if (net.isIP(hostname) && isBlockedAddress(hostname)) {
+    throw new Error("blocked_ip");
+  }
+
+  if (!net.isIP(hostname)) {
+    await resolvePublicAddresses(hostname);
+  }
+}
+
+function publicLookup(hostname: string, _options: unknown, callback: LookupCallback): void {
+  void resolvePublicAddresses(hostname)
+    .then(([entry]) => callback(null, entry.address, entry.family))
+    .catch((error: NodeJS.ErrnoException) => callback(error, "", 0));
+}
+
+async function fetchWithPublicLookup(url: URL, signal: AbortSignal): Promise<http.IncomingMessage> {
+  const client = url.protocol === "https:" ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const request = client.request(
+      url,
+      {
+        method: "GET",
+        lookup: publicLookup,
+        signal,
+        headers: {
+          accept: "text/html,application/xhtml+xml;q=0.9,*/*;q=0.1",
+          "accept-encoding": "identity",
+          "user-agent": "my-nostr-relay-link-preview/1.0",
+        },
+      },
+      resolve,
+    );
+
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+function isAllowedContentType(value: string | undefined): boolean {
+  const mime = value?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  return ALLOWED_CONTENT_TYPES.includes(mime);
+}
+
+async function fetchHtml(inputUrl: URL): Promise<{ html: string; finalUrl: URL }> {
+  let currentUrl = inputUrl;
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+    await validateUrl(currentUrl);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    try {
+      const response = await fetchWithPublicLookup(currentUrl, controller.signal);
+
+      if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400) {
+        response.resume();
+        const location = response.headers.location;
+        if (!location) throw new Error("redirect_without_location");
+        if (redirectCount === MAX_REDIRECTS) throw new Error("too_many_redirects");
+        currentUrl = new URL(Array.isArray(location) ? location[0] : location, currentUrl);
+        continue;
+      }
+
+      if (!response.statusCode || response.statusCode < 200 || response.statusCode >= 300) {
+        response.resume();
+        throw new Error("fetch_failed");
+      }
+
+      const contentType = Array.isArray(response.headers["content-type"])
+        ? response.headers["content-type"][0]
+        : response.headers["content-type"];
+      if (!isAllowedContentType(contentType)) {
+        response.resume();
+        throw new Error("unsupported_content_type");
+      }
+
+      const chunks: Uint8Array[] = [];
+      let received = 0;
+
+      for await (const chunk of response) {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        received += buffer.byteLength;
+        if (received > MAX_HTML_BYTES) {
+          response.destroy();
+          throw new Error("html_too_large");
+        }
+        chunks.push(buffer);
+      }
+
+      const html = new TextDecoder("utf-8", { fatal: false }).decode(Buffer.concat(chunks));
+      return { html, finalUrl: currentUrl };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw new Error("too_many_redirects");
+}
+
+function decodeHtmlEntities(value: string): string {
+  const named: Record<string, string> = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+    nbsp: " ",
+  };
+
+  return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (entity, body: string) => {
+    const lower = body.toLowerCase();
+    if (lower.startsWith("#x")) {
+      return String.fromCodePoint(Number.parseInt(lower.slice(2), 16));
+    }
+    if (lower.startsWith("#")) {
+      return String.fromCodePoint(Number.parseInt(lower.slice(1), 10));
+    }
+    return named[lower] ?? entity;
+  });
+}
+
+function normalizeText(value?: string): string | undefined {
+  const normalized = value?.replace(/\s+/g, " ").trim();
+  return normalized ? decodeHtmlEntities(normalized) : undefined;
+}
+
+function getAttribute(tag: string, name: string): string | undefined {
+  const pattern = new RegExp(`${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s>]+))`, "i");
+  const match = tag.match(pattern);
+  return match?.[1] ?? match?.[2] ?? match?.[3];
+}
+
+function findMetaContent(html: string, names: string[]): string | undefined {
+  const metaPattern = /<meta\b[^>]*>/gi;
+  for (const tag of html.match(metaPattern) ?? []) {
+    const property = getAttribute(tag, "property")?.toLowerCase();
+    const name = getAttribute(tag, "name")?.toLowerCase();
+    if (property && names.includes(property)) return normalizeText(getAttribute(tag, "content"));
+    if (name && names.includes(name)) return normalizeText(getAttribute(tag, "content"));
+  }
+  return undefined;
+}
+
+function findTitle(html: string): string | undefined {
+  const match = html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+  return normalizeText(match?.[1]);
+}
+
+async function safeImageUrl(rawImage: string | undefined, finalUrl: URL): Promise<string | undefined> {
+  if (!rawImage) return undefined;
+
+  try {
+    const imageUrl = new URL(rawImage, finalUrl);
+    await validateUrl(imageUrl);
+    return imageUrl.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+async function extractPreview(html: string, finalUrl: URL): Promise<LinkPreviewData | null> {
+  const title =
+    findMetaContent(html, ["og:title"]) ??
+    findMetaContent(html, ["twitter:title"]) ??
+    findTitle(html);
+
+  if (!title) return null;
+
+  const description =
+    findMetaContent(html, ["og:description"]) ??
+    findMetaContent(html, ["twitter:description"]) ??
+    findMetaContent(html, ["description"]);
+  const rawImage = findMetaContent(html, ["og:image", "og:image:url", "twitter:image", "twitter:image:src"]);
+  const siteName = findMetaContent(html, ["og:site_name"]);
+  const image = await safeImageUrl(rawImage, finalUrl);
+
+  return {
+    url: finalUrl.toString(),
+    domain: finalUrl.hostname.replace(/^www\./, ""),
+    title,
+    ...(description ? { description } : {}),
+    ...(image ? { image } : {}),
+    ...(siteName ? { siteName } : {}),
+  };
+}
+
+export async function GET(request: Request) {
+  const rawUrl = new URL(request.url).searchParams.get("url");
+  if (!rawUrl || rawUrl.length > 2048) {
+    return NextResponse.json({ error: "invalid_url" }, { status: 400 });
+  }
+
+  let targetUrl: URL;
+  try {
+    targetUrl = new URL(rawUrl);
+  } catch {
+    return NextResponse.json({ error: "invalid_url" }, { status: 400 });
+  }
+
+  try {
+    const { html, finalUrl } = await fetchHtml(targetUrl);
+    const preview = await extractPreview(html, finalUrl);
+    if (!preview) {
+      return NextResponse.json({ error: "no_preview" }, { status: 404 });
+    }
+
+    return NextResponse.json(preview, {
+      headers: {
+        "Cache-Control": "s-maxage=86400, stale-while-revalidate=604800",
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "preview_failed" }, { status: 502 });
+  }
+}

--- a/apps/web/app/components/content/ContentRenderer.tsx
+++ b/apps/web/app/components/content/ContentRenderer.tsx
@@ -4,6 +4,7 @@ import { parseContent, type ContentNode } from "../../lib/contentParser";
 import { TextNode } from "./TextNode";
 import { ImageNode } from "./ImageNode";
 import { LinkNode } from "./LinkNode";
+import { LinkPreviewNode } from "./LinkPreviewNode";
 import { QuoteNode } from "./QuoteNode";
 import { EmojiNode } from "./EmojiNode";
 import type { ComponentType } from "react";
@@ -18,6 +19,7 @@ import type { NostrProfile } from "../../lib/types";
 const NODE_RENDERERS: Record<ContentNode["type"], ComponentType<any>> = {
   text: TextNode,
   image: ImageNode,
+  linkPreview: LinkPreviewNode,
   link: LinkNode,
   quote: QuoteNode,
   emoji: EmojiNode,

--- a/apps/web/app/components/content/LinkPreviewNode.tsx
+++ b/apps/web/app/components/content/LinkPreviewNode.tsx
@@ -69,7 +69,7 @@ export function LinkPreviewNode({ url, text }: LinkPreviewNodeProps) {
   }
 
   const { data } = state;
-  const label = data.siteName || data.domain;
+  const label = data.siteName ? `${data.siteName} · ${data.domain}` : data.domain;
 
   return (
     <a

--- a/apps/web/app/components/content/LinkPreviewNode.tsx
+++ b/apps/web/app/components/content/LinkPreviewNode.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { LinkNode } from "./LinkNode";
+
+interface LinkPreviewNodeProps {
+  url: string;
+  text: string;
+}
+
+interface LinkPreviewData {
+  url: string;
+  domain: string;
+  title: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+}
+
+type PreviewState =
+  | { url: string; status: "loading" }
+  | { url: string; status: "success"; data: LinkPreviewData }
+  | { url: string; status: "error" };
+
+function LinkPreviewSkeleton() {
+  return (
+    <div className="block my-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 animate-pulse">
+      <div className="aspect-[1.91/1] w-full bg-gray-200 dark:bg-gray-600" />
+      <div className="p-3">
+        <div className="h-3 w-24 rounded bg-gray-200 dark:bg-gray-600" />
+        <div className="mt-2 h-4 w-3/4 rounded bg-gray-200 dark:bg-gray-600" />
+        <div className="mt-2 h-3 w-full rounded bg-gray-200 dark:bg-gray-600" />
+        <div className="mt-1 h-3 w-2/3 rounded bg-gray-200 dark:bg-gray-600" />
+      </div>
+    </div>
+  );
+}
+
+/** OGPリンクプレビューを表示する。取得失敗時は通常リンクへフォールバックする。 */
+export function LinkPreviewNode({ url, text }: LinkPreviewNodeProps) {
+  const [state, setState] = useState<PreviewState>({ url, status: "loading" });
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(`/api/link-preview?url=${encodeURIComponent(url)}`, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("preview_failed");
+        return (await response.json()) as LinkPreviewData;
+      })
+      .then((data) => {
+        if (!data.title) throw new Error("preview_without_title");
+        setState({ url, status: "success", data });
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        setState({ url, status: "error" });
+      });
+
+    return () => controller.abort();
+  }, [url]);
+
+  if (state.url !== url || state.status === "loading") {
+    return <LinkPreviewSkeleton />;
+  }
+
+  if (state.status === "error") {
+    return <LinkNode url={url} text={text} />;
+  }
+
+  const { data } = state;
+  const label = data.siteName || data.domain;
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className="block my-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-700/50 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+    >
+      {data.image && (
+        <img
+          src={data.image}
+          alt=""
+          loading="lazy"
+          className="aspect-[1.91/1] w-full object-cover bg-gray-100 dark:bg-gray-800"
+        />
+      )}
+      <div className="p-3">
+        <div className="text-xs text-gray-500 dark:text-gray-400 truncate">{label}</div>
+        <div className="mt-1 text-sm font-semibold text-gray-900 dark:text-gray-100 line-clamp-2 break-words">
+          {data.title}
+        </div>
+        {data.description && (
+          <p className="mt-1 text-sm text-gray-700 dark:text-gray-300 line-clamp-3 break-words leading-relaxed">
+            {data.description}
+          </p>
+        )}
+      </div>
+    </a>
+  );
+}

--- a/apps/web/app/lib/__tests__/contentParser.test.ts
+++ b/apps/web/app/lib/__tests__/contentParser.test.ts
@@ -94,7 +94,7 @@ describe("parseContent", () => {
   it("URLパスの途中に画像拡張子がある場合、画像として検出しない", () => {
     const result = parseContent("https://example.com/img.jpg/page");
     expect(result).toEqual([
-      { type: "link", url: "https://example.com/img.jpg/page", text: "example.com/img.jpg/page" },
+      { type: "linkPreview", url: "https://example.com/img.jpg/page", text: "example.com/img.jpg/page" },
     ]);
   });
 
@@ -109,41 +109,41 @@ describe("parseContent", () => {
 
   // ===== link ノード基本テスト =====
 
-  // linkノード: URLのみ
-  it("一般URLのみの場合、linkノード1つを返す", () => {
+  // linkPreviewノード: URLのみ
+  it("一般URLのみの場合、linkPreviewノード1つを返す", () => {
     const result = parseContent("https://example.com/page");
     expect(result).toEqual([
-      { type: "link", url: "https://example.com/page", text: "example.com/page" },
+      { type: "linkPreview", url: "https://example.com/page", text: "example.com/page" },
     ]);
   });
 
-  // linkノード: テキスト + URL + テキスト
-  it("テキストの間に一般URLがある場合、text + link + text に分割する", () => {
+  // linkPreviewノード: テキスト + URL + テキスト
+  it("テキストの間に一般URLがある場合、text + linkPreview + text に分割する", () => {
     const result = parseContent("見て https://example.com/page すごい");
     expect(result).toEqual([
       { type: "text", text: "見て " },
-      { type: "link", url: "https://example.com/page", text: "example.com/page" },
+      { type: "linkPreview", url: "https://example.com/page", text: "example.com/page" },
       { type: "text", text: " すごい" },
     ]);
   });
 
   // linkノード: 複数URL
-  it("複数の一般URLを含む場合、それぞれlinkノードに分離する", () => {
+  it("複数の一般URLを含む場合、最初だけlinkPreviewノードにする", () => {
     const result = parseContent("https://a.com と https://b.com");
     expect(result).toEqual([
-      { type: "link", url: "https://a.com", text: "a.com" },
+      { type: "linkPreview", url: "https://a.com", text: "a.com" },
       { type: "text", text: " と " },
       { type: "link", url: "https://b.com", text: "b.com" },
     ]);
   });
 
-  // linkノード: 画像URL + 一般URL混在
-  it("画像URLと一般URLが混在する場合、image + text + link に分割する", () => {
+  // linkPreviewノード: 画像URL + 一般URL混在
+  it("画像URLと一般URLが混在する場合、image + text + linkPreview に分割する", () => {
     const result = parseContent("https://img.com/photo.jpg と https://example.com");
     expect(result).toEqual([
       { type: "image", url: "https://img.com/photo.jpg" },
       { type: "text", text: " と " },
-      { type: "link", url: "https://example.com", text: "example.com" },
+      { type: "linkPreview", url: "https://example.com", text: "example.com" },
     ]);
   });
 
@@ -153,7 +153,7 @@ describe("parseContent", () => {
   it("短いURLはプロトコルを除去した文字列をtextに使う", () => {
     const result = parseContent("https://example.com");
     expect(result).toEqual([
-      { type: "link", url: "https://example.com", text: "example.com" },
+      { type: "linkPreview", url: "https://example.com", text: "example.com" },
     ]);
   });
 
@@ -166,7 +166,7 @@ describe("parseContent", () => {
     // 50文字超なので49文字 + "…"
     const expectedText = withoutProtocol.slice(0, 49) + "…";
     expect(result).toEqual([
-      { type: "link", url: longUrl, text: expectedText },
+      { type: "linkPreview", url: longUrl, text: expectedText },
     ]);
     expect(expectedText.length).toBe(50);
     expect(expectedText).toContain("…");
@@ -182,7 +182,7 @@ describe("parseContent", () => {
     expect(withoutProtocol.length).toBe(50);
     const result = parseContent(url);
     expect(result).toEqual([
-      { type: "link", url: url, text: withoutProtocol },
+      { type: "linkPreview", url: url, text: withoutProtocol },
     ]);
     // "…" が含まれないことを確認
     expect(withoutProtocol).not.toContain("…");
@@ -195,7 +195,7 @@ describe("parseContent", () => {
     const result = parseContent("(https://example.com)");
     expect(result).toEqual([
       { type: "text", text: "(" },
-      { type: "link", url: "https://example.com", text: "example.com" },
+      { type: "linkPreview", url: "https://example.com", text: "example.com" },
       { type: "text", text: ")" },
     ]);
   });
@@ -204,7 +204,7 @@ describe("parseContent", () => {
   it("URLの後に日本語句読点「。」がある場合、linkとtextに分離する", () => {
     const result = parseContent("https://example.com。次の文");
     expect(result).toEqual([
-      { type: "link", url: "https://example.com", text: "example.com" },
+      { type: "linkPreview", url: "https://example.com", text: "example.com" },
       { type: "text", text: "。次の文" },
     ]);
   });
@@ -213,7 +213,7 @@ describe("parseContent", () => {
   it("URLの後に日本語読点「、」がある場合、linkとtextに分離する", () => {
     const result = parseContent("https://example.com、次");
     expect(result).toEqual([
-      { type: "link", url: "https://example.com", text: "example.com" },
+      { type: "linkPreview", url: "https://example.com", text: "example.com" },
       { type: "text", text: "、次" },
     ]);
   });
@@ -222,7 +222,7 @@ describe("parseContent", () => {
   it("URLの後に全角感嘆符「！」がある場合、linkとtextに分離する", () => {
     const result = parseContent("https://example.com！すごい");
     expect(result).toEqual([
-      { type: "link", url: "https://example.com", text: "example.com" },
+      { type: "linkPreview", url: "https://example.com", text: "example.com" },
       { type: "text", text: "！すごい" },
     ]);
   });
@@ -241,7 +241,7 @@ describe("parseContent", () => {
   it("http://スキームのURLもlinkノードとして検出する", () => {
     const result = parseContent("http://example.com");
     expect(result).toEqual([
-      { type: "link", url: "http://example.com", text: "example.com" },
+      { type: "linkPreview", url: "http://example.com", text: "example.com" },
     ]);
   });
 
@@ -308,7 +308,7 @@ describe("parseContent", () => {
       { type: "text", text: " " },
       { type: "quote", uri: nostrUri },
       { type: "text", text: " " },
-      { type: "link", url: linkUrl, text: "example.com/page" },
+      { type: "linkPreview", url: linkUrl, text: "example.com/page" },
     ]);
   });
 
@@ -346,7 +346,7 @@ describe("parseContent", () => {
     expect(result).toEqual([
       { type: "quote", uri: nostrUri },
       { type: "text", text: " " },
-      { type: "link", url: linkUrl, text: "example.com" },
+      { type: "linkPreview", url: linkUrl, text: "example.com" },
     ]);
   });
 

--- a/apps/web/app/lib/contentParser.ts
+++ b/apps/web/app/lib/contentParser.ts
@@ -7,10 +7,11 @@
 export type ContentNode =
   | { type: "text"; text: string }
   | { type: "image"; url: string }
+  | { type: "linkPreview"; url: string; text: string }
   | { type: "link"; url: string; text: string }
   | { type: "quote"; uri: string }
   | { type: "emoji"; shortcode: string; url: string };
-// 今後追加予定: | { type: "video"; url: string } | { type: "ogp"; url: string; title: string }
+// 今後追加予定: | { type: "video"; url: string }
 
 /** 画像URLにマッチする正規表現パターン（パス途中の拡張子誤検出を防ぐため末尾に先読みを追加） */
 const IMAGE_URL_PATTERN =
@@ -50,7 +51,10 @@ function cleanUrlTrailing(url: string): string {
  * 画像マッチ後の残りテキストに対して使用する
  * 優先順: nostr URI → 一般 URL（重複区間は先にマッチした方が優先）
  */
-function splitTextWithNostrAndLinks(text: string): ContentNode[] {
+function splitTextWithNostrAndLinks(
+  text: string,
+  state: { linkPreviewUsed: boolean },
+): ContentNode[] {
   // すべてのマッチを収集し、位置でソートする
   type MatchEntry =
     | { kind: "nostr"; index: number; length: number; uri: string }
@@ -129,6 +133,9 @@ function splitTextWithNostrAndLinks(text: string): ContentNode[] {
         ? `${identifier.slice(0, 12)}…${identifier.slice(-4)}`
         : identifier;
       nodes.push({ type: "link", url: `https://njump.me/${identifier}`, text: `@${shortId}` });
+    } else if (!state.linkPreviewUsed) {
+      state.linkPreviewUsed = true;
+      nodes.push({ type: "linkPreview", url: entry.url, text: shortenUrl(entry.url) });
     } else {
       nodes.push({ type: "link", url: entry.url, text: shortenUrl(entry.url) });
     }
@@ -216,6 +223,7 @@ export function parseContent(content: string, tags?: string[][]): ContentNode[] 
 
   const nodes: ContentNode[] = [];
   let lastIndex = 0;
+  const parserState = { linkPreviewUsed: false };
 
   // matchAllを使うことでlastIndexの手動リセットが不要
   for (const match of content.matchAll(IMAGE_URL_PATTERN)) {
@@ -226,7 +234,7 @@ export function parseContent(content: string, tags?: string[][]): ContentNode[] 
     if (matchIndex > lastIndex) {
       const text = content.slice(lastIndex, matchIndex);
       if (text.length > 0) {
-        nodes.push(...splitTextWithNostrAndLinks(text));
+        nodes.push(...splitTextWithNostrAndLinks(text, parserState));
       }
     }
 
@@ -240,7 +248,7 @@ export function parseContent(content: string, tags?: string[][]): ContentNode[] 
   if (lastIndex < content.length) {
     const text = content.slice(lastIndex);
     if (text.length > 0) {
-      nodes.push(...splitTextWithNostrAndLinks(text));
+      nodes.push(...splitTextWithNostrAndLinks(text, parserState));
     }
   }
 


### PR DESCRIPTION
## 概要
- 投稿本文内の最初の通常URLをOGPリンクカードとして表示
- OGP取得成功時はURL文字列リンクを隠し、失敗時は従来リンクにフォールバック
- Next.js Route HandlerでOGPを取得し、SSRF対策・timeout・サイズ制限・content-type制限を追加

## 表示
- 画像あり: 上部に横長サムネイル、下にdomain/title/description
- 画像なし: 引用カードに近い枠でテキスト中心に表示

## 検証
- npm run test -- contentParser
- npm run test
- npm run lint（既存warningのみ）
- npm run build

## 注意
- PRのマージはヒロが手動でお願いします。