### PR TITLE
feat: add web hashtag support

### DIFF
--- a/apps/web/app/components/ComposeCard.tsx
+++ b/apps/web/app/components/ComposeCard.tsx
@@ -9,6 +9,7 @@ import { useImageUpload } from "../hooks/useImageUpload";
 import { QuoteNode } from "./content/QuoteNode";
 import { encodeNevent, decodeNevent, decodeNote } from "../lib/nip19";
 import { CLIENT_TAG } from "../lib/constants";
+import { extractHashtags } from "../lib/hashtags";
 
 /** npubの省略表示を生成 */
 function shortenPubkey(pubkey: string): string {
@@ -211,6 +212,9 @@ export function ComposeCard({
         : null;
       const finalContent = neventUri ? `${trimmed}\n${neventUri}` : trimmed;
       const tags: string[][] = [CLIENT_TAG];
+      for (const tag of extractHashtags(finalContent)) {
+        tags.push(["t", tag]);
+      }
       if (internalQuotedEvent) {
         tags.push(["q", internalQuotedEvent.eventId, "", internalQuotedEvent.pubkey ?? ""]);
       }

--- a/apps/web/app/components/HashtagModal.tsx
+++ b/apps/web/app/components/HashtagModal.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect } from "react";
+import { createPortal } from "react-dom";
+import { motion } from "framer-motion";
+import type { Event } from "nostr-tools/core";
+import type { EventCache } from "../hooks/useEventCache";
+import { useHashtagNotes } from "../hooks/useHashtagNotes";
+import type { NostrProfile } from "../lib/types";
+import { normalizeHashtag } from "../lib/hashtags";
+import { NoteCardContent } from "./NoteCardContent";
+
+interface HashtagModalProps {
+  tag: string;
+  isOpen: boolean;
+  onClose: () => void;
+  fetchHashtagNotes: (tag: string) => Promise<Event[]>;
+  cache: EventCache;
+  profiles: Map<string, NostrProfile>;
+  onHashtagClick?: (tag: string) => void;
+}
+
+const HASHTAG_NOTES_PANEL_MIN_HEIGHT_CLASS = "min-h-[420px]";
+
+function HashtagNotesLoadingSkeleton() {
+  return (
+    <div className={`space-y-3 ${HASHTAG_NOTES_PANEL_MIN_HEIGHT_CLASS}`} aria-hidden="true">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="rounded-xl border border-gray-200 bg-white px-4 py-4 dark:border-gray-700 dark:bg-gray-800"
+        >
+          <div className="animate-pulse">
+            <div className="mb-3 flex items-center gap-3">
+              <div className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700" />
+              <div className="flex-1 space-y-2">
+                <div className="h-3 w-32 rounded bg-gray-200 dark:bg-gray-700" />
+                <div className="h-2.5 w-20 rounded bg-gray-200 dark:bg-gray-700" />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <div className="h-3 w-full rounded bg-gray-200 dark:bg-gray-700" />
+              <div className="h-3 w-5/6 rounded bg-gray-200 dark:bg-gray-700" />
+              <div className="h-3 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function HashtagModal({
+  tag,
+  isOpen,
+  onClose,
+  fetchHashtagNotes,
+  cache,
+  profiles,
+  onHashtagClick,
+}: HashtagModalProps) {
+  const normalizedTag = normalizeHashtag(tag);
+  const { notes, isLoading, error } = useHashtagNotes({
+    tag: isOpen ? normalizedTag : null,
+    enabled: isOpen,
+    fetchHashtagNotes,
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <motion.div
+      key="hashtag-modal-overlay"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 px-4 py-6 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.96, y: 12 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.98, y: 8 }}
+        transition={{ duration: 0.2 }}
+        className="relative flex h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-4 top-5 z-20 cursor-pointer rounded-full bg-white/90 p-2 text-gray-500 transition-colors hover:text-gray-900 dark:bg-gray-800/90 dark:text-gray-400 dark:hover:text-gray-100"
+          aria-label="閉じる"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        <div className="border-b border-gray-200 bg-white px-6 py-6 dark:border-gray-700 dark:bg-gray-800 sm:px-8">
+          <h2 className="truncate pr-12 text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            #{normalizedTag}
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            最新50件
+          </p>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5 sm:px-6">
+          {isLoading ? (
+            <HashtagNotesLoadingSkeleton />
+          ) : error ? (
+            <div className={`flex items-center ${HASHTAG_NOTES_PANEL_MIN_HEIGHT_CLASS}`}>
+              <div className="w-full rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+                {error}
+              </div>
+            </div>
+          ) : notes.length === 0 ? (
+            <div className={`flex items-center ${HASHTAG_NOTES_PANEL_MIN_HEIGHT_CLASS}`}>
+              <div className="w-full rounded-xl border border-gray-200 bg-white px-4 py-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
+                このハッシュタグのノートはありません
+              </div>
+            </div>
+          ) : (
+            <div className={`space-y-3 ${HASHTAG_NOTES_PANEL_MIN_HEIGHT_CLASS}`}>
+              {notes.map((note) => (
+                <div
+                  key={note.id}
+                  className="rounded-xl border border-gray-200 bg-white px-4 py-4 dark:border-gray-700 dark:bg-gray-800"
+                >
+                  <NoteCardContent
+                    note={note}
+                    profile={profiles.get(note.pubkey)}
+                    onHold={() => undefined}
+                    onRelease={() => undefined}
+                    cache={cache}
+                    profiles={profiles}
+                    onHashtagClick={onHashtagClick}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>,
+    document.body,
+  );
+}

--- a/apps/web/app/components/LiveCanvas.tsx
+++ b/apps/web/app/components/LiveCanvas.tsx
@@ -31,6 +31,7 @@ import type { EventCache } from "../hooks/useEventCache";
 import type { CustomEmoji, EmojiSet } from "../hooks/useCustomEmojis";
 import type { RecentEmoji } from "../hooks/useRecentEmojis";
 import { UserProfileModal } from "./UserProfileModal";
+import { HashtagModal } from "./HashtagModal";
 
 interface LiveCanvasProps {
   notes: NoteCardType[];
@@ -56,6 +57,7 @@ interface LiveCanvasProps {
   looseEmojis: CustomEmoji[];
   fetchProfiles: (pubkeys: string[]) => void;
   fetchUserRecentNotes: (pubkey: string) => Promise<Event[]>;
+  fetchHashtagNotes: (tag: string) => Promise<Event[]>;
   isFollowing: (targetPubkey: string) => boolean;
   follow: (targetPubkey: string) => Promise<void>;
   unfollow: (targetPubkey: string) => Promise<void>;
@@ -65,10 +67,17 @@ function calcColumnCount(width: number): number {
   return Math.max(1, Math.floor(width / COLUMN_WIDTH));
 }
 
-export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis, emojiSets, looseEmojis, fetchProfiles, fetchUserRecentNotes, isFollowing, follow, unfollow }: LiveCanvasProps) {
+export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pubkey, npub, publishEvent, publishedSlotMapRef, sendReaction, sendRepost, cache, onLogout, isProcessing, recentEmojis, emojiSets, looseEmojis, fetchProfiles, fetchUserRecentNotes, fetchHashtagNotes, isFollowing, follow, unfollow }: LiveCanvasProps) {
   const [columnCount, setColumnCount] = useState(1);
   const [holdSet, setHoldSet] = useState<Set<string>>(() => new Set());
   const [profileModalPubkey, setProfileModalPubkey] = useState<string | null>(null);
+  const [hashtagModalTag, setHashtagModalTag] = useState<string | null>(null);
+
+  const openHashtagModal = useCallback((tag: string) => {
+    // モーダルを重ねずに切り替える。Esc/スクロールロックの競合を避けるため。
+    setProfileModalPubkey(null);
+    setHashtagModalTag(tag);
+  }, []);
 
   /** カードをホールド状態にする */
   const holdCard = useCallback((slotId: string) => {
@@ -509,6 +518,7 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
                               looseEmojis={looseEmojis}
                               fetchProfiles={fetchProfiles}
                               onProfileClick={(targetPubkey) => setProfileModalPubkey(targetPubkey)}
+                              onHashtagClick={openHashtagModal}
                               onReaction={(targetEventId, targetPubkey, emoji, imageUrl) => {
                                 sendReaction(targetEventId, targetPubkey, emoji, imageUrl).catch(console.error);
                               }}
@@ -539,6 +549,7 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
                               looseEmojis={looseEmojis}
                               fetchProfiles={fetchProfiles}
                               onProfileClick={(targetPubkey) => setProfileModalPubkey(targetPubkey)}
+                              onHashtagClick={openHashtagModal}
                               reposterProfile={note.repostInfo ? profiles.get(note.repostInfo.reposterPubkey) : undefined}
                               reactions={reactions.get(note.eventId)}
                               myPubkey={pubkey}
@@ -601,6 +612,18 @@ export function LiveCanvas({ notes, threadCards, profiles, reactions, status, pu
           isFollowing={isFollowing(profileModalPubkey)}
           follow={follow}
           unfollow={unfollow}
+          onHashtagClick={openHashtagModal}
+        />
+      )}
+      {hashtagModalTag && (
+        <HashtagModal
+          tag={hashtagModalTag}
+          isOpen={!!hashtagModalTag}
+          onClose={() => setHashtagModalTag(null)}
+          fetchHashtagNotes={fetchHashtagNotes}
+          cache={cache}
+          profiles={profiles}
+          onHashtagClick={openHashtagModal}
         />
       )}
     </div>

--- a/apps/web/app/components/NoteCard.tsx
+++ b/apps/web/app/components/NoteCard.tsx
@@ -54,9 +54,11 @@ interface NoteCardProps {
   fetchProfiles?: (pubkeys: string[]) => void;
   /** アバターまたは表示名クリック時のハンドラ */
   onProfileClick?: (pubkey: string) => void;
+  /** ハッシュタグクリック時のハンドラ */
+  onHashtagClick?: (tag: string) => void;
 }
 
-export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, onReaction, onRepost, cache, profiles, onHeightChange, onHold, onRelease, onReplyPublish, publishEvent, myProfile, onQuote, recentEmojis, emojiSets, looseEmojis, fetchProfiles, onProfileClick }: NoteCardProps) {
+export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, onReaction, onRepost, cache, profiles, onHeightChange, onHold, onRelease, onReplyPublish, publishEvent, myProfile, onQuote, recentEmojis, emojiSets, looseEmojis, fetchProfiles, onProfileClick, onHashtagClick }: NoteCardProps) {
   const displayName = resolveProfileDisplayName(note.pubkey, profile);
   const cardRef = useRef<HTMLDivElement>(null);
   const [isActionBarOpen, setIsActionBarOpen] = useState(false);
@@ -271,6 +273,7 @@ export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, 
           event.stopPropagation();
           onProfileClick(pubkey);
         } : undefined}
+        onHashtagClick={onHashtagClick}
       />
 
       {/* リアクションバッジ */}

--- a/apps/web/app/components/NoteCardContent.tsx
+++ b/apps/web/app/components/NoteCardContent.tsx
@@ -57,6 +57,7 @@ interface NoteCardContentProps {
   cache?: EventCache;
   profiles?: Map<string, NostrProfile>;
   onProfileClick?: (pubkey: string, event: ReactMouseEvent | ReactKeyboardEvent) => void;
+  onHashtagClick?: (tag: string) => void;
 }
 
 export function NoteCardContent({
@@ -70,6 +71,7 @@ export function NoteCardContent({
   cache,
   profiles,
   onProfileClick,
+  onHashtagClick,
 }: NoteCardContentProps) {
   const isCompact = variant === "compact";
   const displayName = resolveProfileDisplayName(note.pubkey, profile);
@@ -198,6 +200,7 @@ export function NoteCardContent({
           cache={cache}
           profiles={profiles}
           tags={note.tags}
+          onHashtagClick={onHashtagClick}
         />
       </div>
     </>

--- a/apps/web/app/components/ReplyCompose.tsx
+++ b/apps/web/app/components/ReplyCompose.tsx
@@ -6,6 +6,7 @@ import type { NostrProfile } from "../lib/types";
 import type { NostrEvent } from "../types/nostr";
 import { useImageUpload } from "../hooks/useImageUpload";
 import { CLIENT_TAG } from "../lib/constants";
+import { extractHashtags } from "../lib/hashtags";
 
 /** npubの省略表示を生成 */
 function shortenPubkey(pubkey: string): string {
@@ -170,6 +171,9 @@ export function ReplyCompose({
       }
 
       const tags = [...buildReplyTags(), CLIENT_TAG];
+      for (const tag of extractHashtags(trimmed)) {
+        tags.push(["t", tag]);
+      }
 
       const unsignedEvent: NostrEvent = {
         kind: 1,

--- a/apps/web/app/components/ThreadCard.tsx
+++ b/apps/web/app/components/ThreadCard.tsx
@@ -67,6 +67,8 @@ interface ThreadCardProps {
   fetchProfiles?: (pubkeys: string[]) => void;
   /** アバターまたは表示名クリック時のハンドラ */
   onProfileClick?: (pubkey: string) => void;
+  /** ハッシュタグクリック時のハンドラ */
+  onHashtagClick?: (tag: string) => void;
 }
 
 export function ThreadCard({
@@ -88,6 +90,7 @@ export function ThreadCard({
   looseEmojis,
   fetchProfiles,
   onProfileClick,
+  onHashtagClick,
 }: ThreadCardProps) {
   const cardRef = useRef<HTMLDivElement>(null);
   const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
@@ -261,6 +264,7 @@ export function ThreadCard({
             looseEmojis={looseEmojis}
             fetchProfiles={fetchProfiles}
             onProfileClick={onProfileClick}
+            onHashtagClick={onHashtagClick}
           />
         );
       })}
@@ -339,6 +343,8 @@ interface ThreadNoteItemProps {
   fetchProfiles?: (pubkeys: string[]) => void;
   /** アバターまたは表示名クリック時のハンドラ */
   onProfileClick?: (pubkey: string) => void;
+  /** ハッシュタグクリック時のハンドラ */
+  onHashtagClick?: (tag: string) => void;
 }
 
 function ThreadNoteItem({
@@ -363,6 +369,7 @@ function ThreadNoteItem({
   looseEmojis,
   fetchProfiles,
   onProfileClick,
+  onHashtagClick,
 }: ThreadNoteItemProps) {
   const profile = profiles.get(note.pubkey);
 
@@ -491,6 +498,7 @@ function ThreadNoteItem({
             event.stopPropagation();
             onProfileClick(pubkey);
           } : undefined}
+          onHashtagClick={onHashtagClick}
         />
 
         {/* リアクションバッジ */}

--- a/apps/web/app/components/UserProfileModal.tsx
+++ b/apps/web/app/components/UserProfileModal.tsx
@@ -23,6 +23,7 @@ interface UserProfileModalProps {
   isFollowing: boolean;
   follow: (targetPubkey: string) => Promise<void>;
   unfollow: (targetPubkey: string) => Promise<void>;
+  onHashtagClick?: (tag: string) => void;
 }
 
 const RECENT_NOTES_PANEL_MIN_HEIGHT_CLASS = "min-h-[420px]";
@@ -67,6 +68,7 @@ export function UserProfileModal({
   isFollowing,
   follow,
   unfollow,
+  onHashtagClick,
 }: UserProfileModalProps) {
   const { notes, isLoading, error } = useUserRecentNotes({
     pubkey: isOpen ? pubkey : null,
@@ -318,6 +320,7 @@ export function UserProfileModal({
                     onRelease={() => undefined}
                     cache={cache}
                     profiles={profiles}
+                    onHashtagClick={onHashtagClick}
                   />
                 </div>
               ))}

--- a/apps/web/app/components/content/ContentRenderer.tsx
+++ b/apps/web/app/components/content/ContentRenderer.tsx
@@ -7,6 +7,7 @@ import { LinkNode } from "./LinkNode";
 import { LinkPreviewNode } from "./LinkPreviewNode";
 import { QuoteNode } from "./QuoteNode";
 import { EmojiNode } from "./EmojiNode";
+import { HashtagNode } from "./HashtagNode";
 import type { ComponentType } from "react";
 import type { EventCache } from "../../hooks/useEventCache";
 import type { NostrProfile } from "../../lib/types";
@@ -22,6 +23,7 @@ const NODE_RENDERERS: Record<ContentNode["type"], ComponentType<any>> = {
   linkPreview: LinkPreviewNode,
   link: LinkNode,
   quote: QuoteNode,
+  hashtag: HashtagNode,
   emoji: EmojiNode,
 };
 
@@ -35,10 +37,12 @@ interface ContentRendererProps {
   profiles?: Map<string, NostrProfile>;
   /** イベントタグ（カスタム絵文字等の解決に使用） */
   tags?: string[][];
+  /** ハッシュタグクリック時のハンドラ */
+  onHashtagClick?: (tag: string) => void;
 }
 
 /** コンテンツをパースしてノードごとに適切なコンポーネントで描画する */
-export function ContentRenderer({ content, onHold, onRelease, cache, profiles, tags }: ContentRendererProps) {
+export function ContentRenderer({ content, onHold, onRelease, cache, profiles, tags, onHashtagClick }: ContentRendererProps) {
   const nodes = parseContent(content, tags);
 
   // 画像URLリストを抽出
@@ -63,6 +67,8 @@ export function ContentRenderer({ content, onHold, onRelease, cache, profiles, t
             ? { imageUrls, imageIndex: imageIndexMap[index], onHold, onRelease }
             : node.type === "quote"
               ? { cache, profiles: profiles ?? new Map<string, NostrProfile>() }
+              : node.type === "hashtag"
+                ? { onHashtagClick }
               : {};
         return <Renderer key={index} {...props} {...extraProps} />;
       })}

--- a/apps/web/app/components/content/HashtagNode.tsx
+++ b/apps/web/app/components/content/HashtagNode.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+interface HashtagNodeProps {
+  tag: string;
+  text: string;
+  onHashtagClick?: (tag: string) => void;
+}
+
+/** NIP-24 hashtag node */
+export function HashtagNode({ tag, text, onHashtagClick }: HashtagNodeProps) {
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onHashtagClick?.(tag);
+      }}
+      className="inline cursor-pointer p-0 text-sm text-blue-600 hover:underline dark:text-blue-400"
+    >
+      {text}
+    </button>
+  );
+}

--- a/apps/web/app/hooks/useHashtagNotes.ts
+++ b/apps/web/app/hooks/useHashtagNotes.ts
@@ -1,0 +1,92 @@
+import { useEffect, useReducer } from "react";
+import type { Event } from "nostr-tools/core";
+
+interface UseHashtagNotesParams {
+  tag: string | null;
+  enabled: boolean;
+  fetchHashtagNotes: (tag: string) => Promise<Event[]>;
+}
+
+interface UseHashtagNotesResult {
+  notes: Event[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+interface UseHashtagNotesState {
+  requestedTag: string | null;
+  notes: Event[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+type UseHashtagNotesAction =
+  | { type: "start"; tag: string }
+  | { type: "success"; tag: string; notes: Event[] }
+  | { type: "error"; tag: string; error: string };
+
+function reducer(
+  state: UseHashtagNotesState,
+  action: UseHashtagNotesAction,
+): UseHashtagNotesState {
+  switch (action.type) {
+    case "start":
+      return { requestedTag: action.tag, notes: [], isLoading: true, error: null };
+    case "success":
+      if (state.requestedTag !== action.tag) return state;
+      return { requestedTag: action.tag, notes: action.notes, isLoading: false, error: null };
+    case "error":
+      if (state.requestedTag !== action.tag) return state;
+      return { requestedTag: action.tag, notes: [], isLoading: false, error: action.error };
+    default:
+      return state;
+  }
+}
+
+export function useHashtagNotes({
+  tag,
+  enabled,
+  fetchHashtagNotes,
+}: UseHashtagNotesParams): UseHashtagNotesResult {
+  const [state, dispatch] = useReducer(reducer, {
+    requestedTag: null,
+    notes: [],
+    isLoading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!enabled || !tag) return;
+
+    let cancelled = false;
+    dispatch({ type: "start", tag });
+
+    void fetchHashtagNotes(tag)
+      .then((events) => {
+        if (cancelled) return;
+        dispatch({ type: "success", tag, notes: events });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        dispatch({
+          type: "error",
+          tag,
+          error: err instanceof Error ? err.message : "ハッシュタグの取得に失敗しました",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, tag, fetchHashtagNotes]);
+
+  if (!enabled || !tag) {
+    return { notes: [], isLoading: false, error: null };
+  }
+
+  if (state.requestedTag !== tag) {
+    return { notes: [], isLoading: true, error: null };
+  }
+
+  return state;
+}

--- a/apps/web/app/hooks/useNostrRelay.ts
+++ b/apps/web/app/hooks/useNostrRelay.ts
@@ -29,6 +29,7 @@ interface UseNostrRelayResult {
   looseEmojis: CustomEmoji[];
   fetchProfiles: (pubkeys: string[]) => void;
   fetchUserRecentNotes: (pubkey: string) => Promise<Event[]>;
+  fetchHashtagNotes: (tag: string) => Promise<Event[]>;
   publishEvent: (event: NostrEvent) => Promise<void>;
   sendReaction: (targetEventId: string, targetPubkey: string, emoji: string, imageUrl?: string) => Promise<void>;
   sendRepost: (targetEventId: string, targetPubkey: string, originalEvent: NostrEvent) => Promise<void>;
@@ -91,6 +92,30 @@ export function useNostrRelay(
       return recentNotes;
     },
     [pool, relayUrls, cache],
+  );
+
+  const fetchHashtagNotes = useCallback(
+    async (tag: string): Promise<Event[]> => {
+      if (!pool || relayUrls.length === 0) {
+        throw new Error("ハッシュタグを取得できませんでした。リレー接続を確認してください");
+      }
+
+      const events = await pool.querySync(
+        relayUrls,
+        { kinds: [1], "#t": [tag], limit: 50 },
+        { maxWait: BOOTSTRAP_EOSE_TIMEOUT },
+      );
+
+      const hashtagNotes = events
+        .filter((event) => event.kind === 1)
+        .sort((a, b) => b.created_at - a.created_at)
+        .slice(0, 50);
+
+      cache.addEvents(hashtagNotes);
+      fetchProfiles(Array.from(new Set(hashtagNotes.map((event) => event.pubkey))));
+      return hashtagNotes;
+    },
+    [pool, relayUrls, cache, fetchProfiles],
   );
 
   /** 署名済みイベントを全リレーにpublishする（1つ以上のリレーに成功すればOK） */
@@ -215,6 +240,7 @@ export function useNostrRelay(
     looseEmojis,
     fetchProfiles,
     fetchUserRecentNotes,
+    fetchHashtagNotes,
     publishEvent,
     sendReaction,
     sendRepost,

--- a/apps/web/app/lib/__tests__/contentParser.test.ts
+++ b/apps/web/app/lib/__tests__/contentParser.test.ts
@@ -418,8 +418,8 @@ describe("parseContent", () => {
     ]);
   });
 
-  // emoji タグ以外のタグは無視
-  it("emoji タグ以外のタグは無視する", () => {
+  // emoji タグ以外のタグは無視（t tagはNIP-24 hashtagとして扱う）
+  it("emoji タグ以外は無視し、t tagは補完hashtagとして扱う", () => {
     const tags = [
       ["p", "pubkey123"],
       ["emoji", "heart", "https://example.com/heart.png"],
@@ -428,6 +428,8 @@ describe("parseContent", () => {
     const result = parseContent(":heart:", tags);
     expect(result).toEqual([
       { type: "emoji", shortcode: "heart", url: "https://example.com/heart.png" },
+      { type: "text", text: "\n" },
+      { type: "hashtag", tag: "nostr", text: "#nostr" },
     ]);
   });
 
@@ -447,6 +449,36 @@ describe("parseContent", () => {
       { type: "emoji", shortcode: "star", url: "https://example.com/star.png" },
       { type: "text", text: " good " },
       { type: "emoji", shortcode: "star", url: "https://example.com/star.png" },
+    ]);
+  });
+
+  it("event.tagsに対応する本文中の#tagだけhashtagノードにする", () => {
+    const result = parseContent("hello #Pokemon #写真 #missing", [
+      ["t", "pokemon"],
+      ["t", "写真"],
+    ]);
+    expect(result).toEqual([
+      { type: "text", text: "hello " },
+      { type: "hashtag", tag: "pokemon", text: "#Pokemon" },
+      { type: "text", text: " " },
+      { type: "hashtag", tag: "写真", text: "#写真" },
+      { type: "text", text: " #missing" },
+    ]);
+  });
+
+  it("event.tagsにない本文中の#tagはtextのままにする", () => {
+    const result = parseContent("hello #tag");
+    expect(result).toEqual([{ type: "text", text: "hello #tag" }]);
+  });
+
+  it("本文にないt tagは末尾に表示上だけ補完する", () => {
+    const result = parseContent("hello", [["t", "nostr"], ["t", "写真"]]);
+    expect(result).toEqual([
+      { type: "text", text: "hello" },
+      { type: "text", text: "\n" },
+      { type: "hashtag", tag: "nostr", text: "#nostr" },
+      { type: "text", text: " " },
+      { type: "hashtag", tag: "写真", text: "#写真" },
     ]);
   });
 });

--- a/apps/web/app/lib/__tests__/hashtags.test.ts
+++ b/apps/web/app/lib/__tests__/hashtags.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { extractHashtags } from "../hashtags";
+
+describe("extractHashtags", () => {
+  it("本文先頭または空白直後のタグだけを抽出する", () => {
+    expect(extractHashtags("#tag ok #next abc#bad"))
+      .toEqual(["tag", "next"]);
+  });
+
+  it("日本語タグと数字を抽出する", () => {
+    expect(extractHashtags("#ポケモン #写真 #今日の1枚"))
+      .toEqual(["ポケモン", "写真", "今日の1枚"]);
+  });
+
+  it("英字部分をlowercaseし重複排除する", () => {
+    expect(extractHashtags("#Pokemon #pokemon #POKEモン"))
+      .toEqual(["pokemon", "pokeモン"]);
+  });
+
+  it("空白・改行・句読点・括弧・URL区切り文字で終端する", () => {
+    expect(extractHashtags("#one,#two (#three)\n#four/#five #six。 #seven?x=1 #eight&x"))
+      .toEqual(["one", "four", "six", "seven", "eight"]);
+  });
+
+  it("#単体、URL fragment、単語途中の#tagを除外する", () => {
+    expect(extractHashtags("# https://example.com/page#section abc#tag"))
+      .toEqual([]);
+  });
+});

--- a/apps/web/app/lib/contentParser.ts
+++ b/apps/web/app/lib/contentParser.ts
@@ -3,6 +3,8 @@
  * Nostrイベントのcontent文字列を構造化されたノードに分解する
  */
 
+import { extractEventHashtags, findHashtagMatches } from "./hashtags";
+
 /** コンテンツノードの型定義（discriminated union） */
 export type ContentNode =
   | { type: "text"; text: string }
@@ -10,6 +12,7 @@ export type ContentNode =
   | { type: "linkPreview"; url: string; text: string }
   | { type: "link"; url: string; text: string }
   | { type: "quote"; uri: string }
+  | { type: "hashtag"; tag: string; text: string }
   | { type: "emoji"; shortcode: string; url: string };
 // 今後追加予定: | { type: "video"; url: string }
 
@@ -201,6 +204,68 @@ function splitTextWithEmoji(
 }
 
 /**
+ * textノード内のevent.tags由来のt tagだけをhashtagノードに分割する。
+ * 本文に存在しないt tagは末尾に表示上だけ補完する（contentは書き換えない）。
+ */
+function splitTextWithHashtags(
+  nodes: ContentNode[],
+  normalizedTags: string[],
+): ContentNode[] {
+  if (normalizedTags.length === 0) return nodes;
+
+  const allowedTags = new Set(normalizedTags);
+  const foundTags = new Set<string>();
+  const result: ContentNode[] = [];
+
+  for (const node of nodes) {
+    if (node.type !== "text") {
+      result.push(node);
+      continue;
+    }
+
+    const matches = findHashtagMatches(node.text).filter((match) =>
+      allowedTags.has(match.tag),
+    );
+
+    if (matches.length === 0) {
+      result.push(node);
+      continue;
+    }
+
+    let lastIndex = 0;
+    for (const match of matches) {
+      if (match.index > lastIndex) {
+        result.push({ type: "text", text: node.text.slice(lastIndex, match.index) });
+      }
+
+      result.push({ type: "hashtag", tag: match.tag, text: match.text });
+      foundTags.add(match.tag);
+      lastIndex = match.index + match.length;
+    }
+
+    if (lastIndex < node.text.length) {
+      result.push({ type: "text", text: node.text.slice(lastIndex) });
+    }
+  }
+
+  const missingTags = normalizedTags.filter((tag) => !foundTags.has(tag));
+  if (missingTags.length > 0) {
+    if (result.length > 0) {
+      result.push({ type: "text", text: "\n" });
+    }
+
+    for (const [index, tag] of missingTags.entries()) {
+      if (index > 0) {
+        result.push({ type: "text", text: " " });
+      }
+      result.push({ type: "hashtag", tag, text: `#${tag}` });
+    }
+  }
+
+  return result;
+}
+
+/**
  * content文字列をパースし、ContentNode配列を返す
  *
  * - 画像URL（.jpg, .jpeg, .png, .gif, .webp で終わるHTTP(S) URL）を検出
@@ -209,7 +274,13 @@ function splitTextWithEmoji(
  * - tagsにemojiタグが含まれていれば、:shortcode: をカスタム絵文字ノードに変換する（NIP-30）
  */
 export function parseContent(content: string, tags?: string[][]): ContentNode[] {
-  if (!content) return [];
+  const eventHashtags = extractEventHashtags(tags);
+  if (!content) {
+    return eventHashtags.flatMap((tag, index): ContentNode[] => [
+      ...(index > 0 ? [{ type: "text" as const, text: " " }] : []),
+      { type: "hashtag", tag, text: `#${tag}` },
+    ]);
+  }
 
   // tagsからemojiマップを構築
   const emojiMap = new Map<string, string>();
@@ -252,10 +323,15 @@ export function parseContent(content: string, tags?: string[][]): ContentNode[] 
     }
   }
 
+  let result = nodes;
+
+  // event.tagsにt tagがある場合のみハッシュタグをクリック可能にする
+  result = splitTextWithHashtags(result, eventHashtags);
+
   // カスタム絵文字の後処理（emojiMapが空でない場合のみ）
   if (emojiMap.size > 0) {
-    return splitTextWithEmoji(nodes, emojiMap);
+    result = splitTextWithEmoji(result, emojiMap);
   }
 
-  return nodes;
+  return result;
 }

--- a/apps/web/app/lib/hashtags.ts
+++ b/apps/web/app/lib/hashtags.ts
@@ -1,0 +1,103 @@
+/** NIP-24 hashtag utilities */
+
+/**
+ * ハッシュタグ終端文字。
+ * 空白・改行・句読点・括弧・URL区切り文字などでタグを終了する。
+ */
+const HASHTAG_TERMINATOR_PATTERN = /[\s\u3000.,;:!?。、，．！？；：「」『』（）()\[\]{}<>〈〉《》【】…‥、/\\|"'`“”‘’#?&=]/u;
+
+/** タグ開始条件: 本文先頭、または直前が空白文字 */
+function isValidHashtagStart(text: string, hashIndex: number): boolean {
+  return hashIndex === 0 || /\s/u.test(text[hashIndex - 1]);
+}
+
+/** NIP-24検索用にタグを正規化する（英字部分をlowercase、先頭#は除去） */
+export function normalizeHashtag(tag: string): string {
+  return tag.replace(/^#+/u, "").toLocaleLowerCase();
+}
+
+export interface HashtagMatch {
+  /** 正規化済みタグ（event.tagsのt tag/search filterに使う） */
+  tag: string;
+  /** content内の開始位置（#を含む） */
+  index: number;
+  /** content内の長さ（#を含む） */
+  length: number;
+  /** content内の元表記（#を含む） */
+  text: string;
+}
+
+/**
+ * 本文からNIP-24用ハッシュタグを抽出する。
+ * - 開始: # が本文先頭、または直前が空白文字
+ * - 終端: 空白、改行、句読点、括弧、URL区切り文字など
+ * - #単体、URL fragment、abc#tag は除外
+ * - 英字部分はlowercase、重複は初出順で排除
+ */
+export function findHashtagMatches(text: string): HashtagMatch[] {
+  const matches: HashtagMatch[] = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] !== "#" || !isValidHashtagStart(text, index)) {
+      continue;
+    }
+
+    let end = index + 1;
+    while (end < text.length && !HASHTAG_TERMINATOR_PATTERN.test(text[end])) {
+      end += 1;
+    }
+
+    if (end === index + 1) {
+      continue;
+    }
+
+    const rawText = text.slice(index, end);
+    const tag = normalizeHashtag(rawText);
+    if (!tag) {
+      continue;
+    }
+
+    matches.push({ tag, index, length: rawText.length, text: rawText });
+    index = end - 1;
+  }
+
+  return matches;
+}
+
+/** 投稿用: 重複排除済みの正規化タグを返す */
+export function extractHashtags(text: string): string[] {
+  const seen = new Set<string>();
+  const tags: string[] = [];
+
+  for (const match of findHashtagMatches(text)) {
+    if (seen.has(match.tag)) {
+      continue;
+    }
+    seen.add(match.tag);
+    tags.push(match.tag);
+  }
+
+  return tags;
+}
+
+/** event.tags から重複排除済みの正規化済み t tag を取り出す */
+export function extractEventHashtags(tags?: string[][]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const tag of tags ?? []) {
+    if (tag[0] !== "t" || !tag[1]) {
+      continue;
+    }
+
+    const normalized = normalizeHashtag(tag[1]);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+
+    seen.add(normalized);
+    result.push(normalized);
+  }
+
+  return result;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -23,6 +23,7 @@ export default function Home() {
     looseEmojis,
     fetchProfiles,
     fetchUserRecentNotes,
+    fetchHashtagNotes,
     publishEvent,
     sendReaction,
     sendRepost,
@@ -64,6 +65,7 @@ export default function Home() {
         looseEmojis={looseEmojis}
         fetchProfiles={fetchProfiles}
         fetchUserRecentNotes={fetchUserRecentNotes}
+        fetchHashtagNotes={fetchHashtagNotes}
         isFollowing={isFollowing}
         follow={follow}
         unfollow={unfollow}


### PR DESCRIPTION
## Summary
- add NIP-24 hashtag extraction utilities with Japanese tag support and tests
- attach `t` tags when publishing notes from compose and reply flows
- render tagged hashtags as clickable content and append missing `t` tags visually
- add hashtag modal that fetches non-follow-limited notes via `#t` query

## Verification
- `npm test`
- `npm run lint` (passes with existing warnings)
- `npm run build`

## Notes
- Existing notes without `t` tags are not backfilled and are not included in hashtag modal results.
- NIP-50/full-text search is intentionally out of scope.
