### PR TITLE
フロントエンド依存関係のメジャーアップ候補を更新

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "framer-motion": "^12.38.0",
         "frimousse": "^0.3.0",
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.16.0",
         "next": "^16.2.3",
         "nostr-tools": "^2.23.3",
         "react": "^19.2.5",
@@ -19,13 +19,13 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@tailwindcss/typography": "^0.5.19",
-        "@types/node": "^20.19.39",
+        "@types/node": "^22.19.19",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "^16.2.3",
         "tailwindcss": "^4",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.4"
       }
     },
@@ -1958,9 +1958,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5491,9 +5491,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -7083,9 +7083,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "framer-motion": "^12.38.0",
     "frimousse": "^0.3.0",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.16.0",
     "next": "^16.2.3",
     "nostr-tools": "^2.23.3",
     "react": "^19.2.5",
@@ -21,13 +21,13 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/typography": "^0.5.19",
-    "@types/node": "^20.19.39",
+    "@types/node": "^22.19.19",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "^16.2.3",
     "tailwindcss": "^4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.4"
   }
 }


### PR DESCRIPTION
## 概要
フロントエンド（apps/web）のメジャーバージョンアップ候補を確認し、ローカル検証で問題なかったものだけ更新しました。

## 更新内容
- `lucide-react`: `^0.577.0` -> `^1.16.0`
- `typescript`: `^5.9.3` -> `^6.0.3`
- `@types/node`: `^20.19.39` -> `^22.19.19`
  - GitHub Actions の Frontend CI が Node 22 のため、最新の Node 25 型定義ではなく Node 22 系に合わせています

## 見送り
- `eslint`: `^9` -> `^10.4.0`
  - `eslint-config-next` 配下の ESLint plugins がまだ ESLint 10 を peer range に含めておらず、`npm ls` が invalid になるため見送りました

## 検証
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm run test`

## 補足
- `npm run lint` は既存警告のみで成功しています
- `npm run build` で既存の複数 lockfile による Turbopack root 推定 warning が出ますが、ビルドは成功しています
- `npm audit` は既存の脆弱性を報告しています（2 moderate, 1 high）。今回のメジャーアップ範囲外として未対応です
