### PR TITLE
リアクションcontentを単一絵文字に制限

### DIFF
--- a/apps/web/app/hooks/useNostrReactions.ts
+++ b/apps/web/app/hooks/useNostrReactions.ts
@@ -6,6 +6,7 @@ import {
   REACTION_POLL_INTERVAL,
   REACTION_SINCE_SAFETY_MARGIN,
 } from "../lib/constants";
+import { normalizeReactionContent } from "../lib/reactionContent";
 import type { NoteCard, Reactions } from "../lib/types";
 
 /** カスタム絵文字（:shortcode: 形式）のイベントタグから画像URLを取得する */
@@ -37,14 +38,6 @@ export function useNostrReactions(
   const reactionSubRef = useRef<SubCloser | null>(null);
   const reactionIntervalRef = useRef<number | null>(null);
   const lastReactionSubClosedAtRef = useRef<number | undefined>(undefined);
-
-  /** リアクションのcontentを正規化する */
-  const normalizeReactionContent = useCallback((content: string): string | null => {
-    if (content === "+" || content === "") return "👍";
-    if (content === "-") return "👎";
-    if (content.startsWith(":") && content.endsWith(":") && content.length > 2) return content;
-    return content;
-  }, []);
 
   /** kind:7リアクションイベントを集計に追加する */
   const addReaction = useCallback((event: Event) => {
@@ -79,7 +72,7 @@ export function useNostrReactions(
       }
       return next;
     });
-  }, [normalizeReactionContent]);
+  }, []);
 
   // kind:7 subscribe（initialEventIdsが空でなくなったら開始）
   useEffect(() => {
@@ -202,7 +195,7 @@ export function useNostrReactions(
       seenReactionIdsRef.current.clear();
       setReactions(new Map());
     };
-  }, [pool, relayUrls, initialEventIds, addReaction, normalizeReactionContent, notesRef, newNotesMinCreatedAtRef]);
+  }, [pool, relayUrls, initialEventIds, addReaction, notesRef, newNotesMinCreatedAtRef]);
 
   return { reactions, addReaction };
 }

--- a/apps/web/app/hooks/useRecentEmojis.ts
+++ b/apps/web/app/hooks/useRecentEmojis.ts
@@ -2,34 +2,11 @@ import { useCallback, useEffect, useState } from "react";
 import type { SimplePool } from "nostr-tools/pool";
 import type { Event } from "nostr-tools/core";
 import type { SubCloser } from "nostr-tools/abstract-pool";
+import { isCustomEmojiShortcode, isValidRecentEmoji } from "../lib/reactionContent";
 
 export interface RecentEmoji {
   emoji: string;       // Unicode emoji or ":shortcode:"
   imageUrl?: string;   // Only for custom emojis
-}
-
-/** contentが単一のUnicode絵文字かを判定する（Intl.Segmenter使用） */
-function isUnicodeEmoji(content: string): boolean {
-  if (content.length === 0) return false;
-  const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
-  const segments = [...segmenter.segment(content)];
-  if (segments.length !== 1) return false;
-  // Extended_Pictographic: 一般的な絵文字、Regional_Indicator: 国旗、\u20e3: キーキャップ
-  return /\p{Extended_Pictographic}/u.test(content) || /\p{Regional_Indicator}/u.test(content) || /\u20e3/u.test(content);
-}
-
-/** :shortcode: 形式のカスタム絵文字かを判定する */
-function isCustomEmojiShortcode(content: string): boolean {
-  return content.startsWith(":") && content.endsWith(":") && content.length > 2;
-}
-
-/** 最近使った絵文字として有効かを判定する（+, -, 空文字を除外、Unicode絵文字またはカスタム絵文字） */
-function isValidRecentEmoji(content: string): boolean {
-  // +, -, 空文字を除外
-  if (content === "+" || content === "-" || content === "") return false;
-
-  // Unicode絵文字またはカスタム絵文字(:shortcode:形式)を対象
-  return isUnicodeEmoji(content) || isCustomEmojiShortcode(content);
 }
 
 /** イベントのタグからカスタム絵文字のURLを抽出する */

--- a/apps/web/app/lib/__tests__/reactionContent.test.ts
+++ b/apps/web/app/lib/__tests__/reactionContent.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  isCustomEmojiShortcode,
+  isUnicodeEmoji,
+  isValidRecentEmoji,
+  normalizeReactionContent,
+} from "../reactionContent";
+
+describe("reactionContent", () => {
+  describe("normalizeReactionContent", () => {
+    it("NIP-25のlike/dislike省略表現を既存どおり正規化する", () => {
+      expect(normalizeReactionContent("+")).toBe("👍");
+      expect(normalizeReactionContent("")).toBe("👍");
+      expect(normalizeReactionContent("-")).toBe("👎");
+    });
+
+    it("単一のUnicode絵文字を許容する", () => {
+      expect(normalizeReactionContent("😀")).toBe("😀");
+      expect(normalizeReactionContent("👍🏽")).toBe("👍🏽");
+      expect(normalizeReactionContent("🇯🇵")).toBe("🇯🇵");
+      expect(normalizeReactionContent("1️⃣")).toBe("1️⃣");
+    });
+
+    it("単一のcustom emoji shortcodeを許容する", () => {
+      expect(normalizeReactionContent(":blobcat:")).toBe(":blobcat:");
+      expect(normalizeReactionContent(":blob-cat_123:")).toBe(":blob-cat_123:");
+    });
+
+    it("複数emojiや任意文字列を棄却する", () => {
+      expect(normalizeReactionContent("😀😀")).toBeNull();
+      expect(normalizeReactionContent("😀 ok")).toBeNull();
+      expect(normalizeReactionContent("ok")).toBeNull();
+      expect(normalizeReactionContent("👍:blobcat:")).toBeNull();
+    });
+
+    it("不正なcustom emoji shortcodeを棄却する", () => {
+      expect(normalizeReactionContent("::")).toBeNull();
+      expect(normalizeReactionContent(":blobcat::party:")).toBeNull();
+      expect(normalizeReactionContent(":blob cat:")).toBeNull();
+      expect(normalizeReactionContent(":blobcat")).toBeNull();
+      expect(normalizeReactionContent("blobcat:")).toBeNull();
+    });
+  });
+
+  it("recent emoji用の判定では+, -, 空文字を除外する", () => {
+    expect(isValidRecentEmoji("😀")).toBe(true);
+    expect(isValidRecentEmoji(":blobcat:")).toBe(true);
+    expect(isValidRecentEmoji("+")).toBe(false);
+    expect(isValidRecentEmoji("-")).toBe(false);
+    expect(isValidRecentEmoji("")).toBe(false);
+  });
+
+  it("単一emojiとcustom emoji shortcodeの個別判定を公開する", () => {
+    expect(isUnicodeEmoji("😀")).toBe(true);
+    expect(isUnicodeEmoji("😀😀")).toBe(false);
+    expect(isCustomEmojiShortcode(":blobcat:")).toBe(true);
+    expect(isCustomEmojiShortcode(":blobcat::party:")).toBe(false);
+  });
+});

--- a/apps/web/app/lib/reactionContent.ts
+++ b/apps/web/app/lib/reactionContent.ts
@@ -1,0 +1,28 @@
+/** contentが単一のUnicode絵文字かを判定する（Intl.Segmenter使用） */
+export function isUnicodeEmoji(content: string): boolean {
+  if (content.length === 0) return false;
+  const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+  const segments = [...segmenter.segment(content)];
+  if (segments.length !== 1) return false;
+  // Extended_Pictographic: 一般的な絵文字、Regional_Indicator: 国旗、\u20e3: キーキャップ
+  return /\p{Extended_Pictographic}/u.test(content) || /\p{Regional_Indicator}/u.test(content) || /\u20e3/u.test(content);
+}
+
+/** :shortcode: 形式のカスタム絵文字かを判定する */
+export function isCustomEmojiShortcode(content: string): boolean {
+  return /^:[^:\s]+:$/.test(content);
+}
+
+/** 最近使った絵文字として有効かを判定する（+, -, 空文字を除外、Unicode絵文字またはカスタム絵文字） */
+export function isValidRecentEmoji(content: string): boolean {
+  if (content === "+" || content === "-" || content === "") return false;
+  return isUnicodeEmoji(content) || isCustomEmojiShortcode(content);
+}
+
+/** kind:7リアクションのcontentを集計用に正規化する。不正なcontentはnullを返す */
+export function normalizeReactionContent(content: string): string | null {
+  if (content === "+" || content === "") return "👍";
+  if (content === "-") return "👎";
+  if (isCustomEmojiShortcode(content) || isUnicodeEmoji(content)) return content;
+  return null;
+}


### PR DESCRIPTION
## 概要
- kind:7 リアクションの content validator を追加
- Unicode emoji は単一 grapheme のみ許容
- custom emoji は単一の :shortcode: のみ許容
- + / 空文字 / - の既存NIP-25正規化は維持
- recent emoji 側の判定を共通化

## 検証
- npm ci
- npm --prefix apps/web test -- app/lib/__tests__/reactionContent.test.ts
- npm --prefix apps/web test
- npm --prefix apps/web run lint
- npm --prefix apps/web run build

## 補足
- tsc --noEmit は既存の Vitest globals 型設定不足で失敗