### PR TITLE
chore(relay): Cargo.lock の依存を更新

### DIFF
--- a/services/relay/Cargo.lock
+++ b/services/relay/Cargo.lock
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.4"
+version = "1.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+checksum = "6c9b9de216a988dd54b754a82a7660cfe14cee4f6782ae4524470972fa0ccb39"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -145,10 +145,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.114.0"
+version = "1.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af371ac7d45e005e4e944738d2744cdcef86c0662f38d6f9df3ba69826ab6e62"
+checksum = "8c937c55ae3030bec4431c0d9146e33d2b3e5f54bb47ed32597068200c56affc"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -425,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",


### PR DESCRIPTION
## 概要

services/relay の Cargo 依存を確認し、Cargo.toml の変更を伴わない patch/minor 更新だけを Cargo.lock に反映しました。

## 更新内容

direct dependency:
- aws-sdk-dynamodb: 1.114.0 -> 1.116.0

transitive dependency:
- aws-runtime: 1.7.4 -> 1.7.5
- aws-smithy-types: 1.4.9 -> 1.5.0

## 方針確認

- Cargo.toml は変更していません。
- services/relay/Cargo.lock のみ変更しています。
- major 更新は含めていません。
- apps/web、terraform、deploy は触っていません。

## 検証

- `cd services/relay && cargo clippy --all-targets --all-features -- -D warnings`
- `cd services/relay && cargo test`

どちらも成功しました。`cargo test` では既存の unused import warning が 1 件表示されましたが、テストは全件成功しています。

## 自動適用しなかった候補

- aws-config: 1.8.18 -> 1.9.0 は現行ツールチェーン Rust 1.93.1 では `requires Rust 1.94.1` のため未適用です。
- aws-sdk-dynamodb: crates.io 上の 1.117.0 は `cargo upgrade` 上は最新候補ですが、今回の lock-only 更新では Rust 1.93.1 で解決できる 1.116.0 までにしています。