### PR TITLE
カスタム絵文字リアクションを画像URL別に集計する

### DIFF
--- a/apps/web/app/components/NoteCard.tsx
+++ b/apps/web/app/components/NoteCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRef, useEffect, useState, useCallback } from "react";
-import type { NoteCard as NoteCardType, NostrProfile } from "../lib/types";
+import type { NoteCard as NoteCardType, NostrProfile, ReactionSummary } from "../lib/types";
+import { reactionKey } from "../lib/reactions";
 import type { NostrEvent } from "../types/nostr";
 import { ActionBar } from "./ActionBar";
 import { NoteCardContent, resolveProfileDisplayName } from "./NoteCardContent";
@@ -17,7 +18,7 @@ interface NoteCardProps {
   /** リポスターのプロフィール情報 */
   reposterProfile?: NostrProfile;
   /** リアクション集計（絵文字 → {件数, 画像URL, 送信者pubkey集合}） */
-  reactions?: Map<string, { count: number; imageUrl?: string; pubkeys: Set<string> }>;
+  reactions?: Map<string, ReactionSummary>;
   /** 自分のpubkey（リアクション済み判定用） */
   myPubkey?: string;
   /** リアクション送信ハンドラ */
@@ -283,17 +284,17 @@ export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, 
       {/* リアクションバッジ */}
       {reactions && reactions.size > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5">
-          {Array.from(reactions.entries()).map(([emoji, { count, imageUrl, pubkeys }]) => {
+          {Array.from(reactions.entries()).map(([key, { emoji, count, imageUrl, pubkeys }]) => {
             const reacted = !!(myPubkey && pubkeys.has(myPubkey));
             return (
               <button
-                key={emoji}
+                key={key}
                 type="button"
                 ref={(el) => {
                   if (el) {
-                    badgeRefs.current.set(emoji, el);
+                    badgeRefs.current.set(key, el);
                   } else {
-                    badgeRefs.current.delete(emoji);
+                    badgeRefs.current.delete(key);
                   }
                 }}
                 aria-disabled={reacted || undefined}
@@ -303,9 +304,9 @@ export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, 
                     onReaction(emoji, imageUrl);
                   }
                 }}
-                onMouseEnter={(e) => handleBadgeMouseEnter(emoji, e.currentTarget)}
+                onMouseEnter={(e) => handleBadgeMouseEnter(key, e.currentTarget)}
                 onMouseLeave={handleBadgeMouseLeave}
-                onTouchStart={(e) => handleBadgeTouchStart(emoji, e.currentTarget)}
+                onTouchStart={(e) => handleBadgeTouchStart(key, e.currentTarget)}
                 onTouchEnd={handleBadgeTouchEnd}
                 onTouchCancel={handleBadgeTouchEnd}
                 onTouchMove={handleBadgeTouchMove}
@@ -364,7 +365,7 @@ export function NoteCard({ note, profile, reposterProfile, reactions, myPubkey, 
             onRelease?.();
           }
         }}
-        isAlreadyReacted={!!(myPubkey && reactions?.get("+")?.pubkeys?.has(myPubkey))}
+        isAlreadyReacted={!!(myPubkey && reactions?.get(reactionKey("👍"))?.pubkeys?.has(myPubkey))}
         onRepost={async () => {
           try {
             if (onRepost) {

--- a/apps/web/app/components/ThreadCard.tsx
+++ b/apps/web/app/components/ThreadCard.tsx
@@ -6,7 +6,9 @@ import type {
   ThreadNote,
   NostrProfile,
   Reactions,
+  ReactionSummary,
 } from "../lib/types";
+import { reactionKey } from "../lib/reactions";
 import type { NostrEvent } from "../types/nostr";
 import type { EventCache } from "../hooks/useEventCache";
 import { ActionBar } from "./ActionBar";
@@ -309,10 +311,7 @@ export function ThreadCard({
 interface ThreadNoteItemProps {
   note: ThreadNote;
   profiles: Map<string, NostrProfile>;
-  noteReactions?: Map<
-    string,
-    { count: number; imageUrl?: string; pubkeys: Set<string> }
-  >;
+  noteReactions?: Map<string, ReactionSummary>;
   myPubkey?: string;
   onReaction?: (
     targetEventId: string,
@@ -511,17 +510,17 @@ function ThreadNoteItem({
         {noteReactions && noteReactions.size > 0 && (
           <div className="mt-1.5 ml-8 flex flex-wrap gap-1">
             {Array.from(noteReactions.entries()).map(
-              ([emoji, { count, imageUrl, pubkeys }]) => {
+              ([key, { emoji, count, imageUrl, pubkeys }]) => {
                 const reacted = !!(myPubkey && pubkeys.has(myPubkey));
                 return (
                   <button
-                    key={emoji}
+                    key={key}
                     type="button"
                     ref={(el) => {
                       if (el) {
-                        badgeRefs.current.set(emoji, el);
+                        badgeRefs.current.set(key, el);
                       } else {
-                        badgeRefs.current.delete(emoji);
+                        badgeRefs.current.delete(key);
                       }
                     }}
                     aria-disabled={reacted || undefined}
@@ -531,9 +530,9 @@ function ThreadNoteItem({
                         onReaction(note.eventId, note.pubkey, emoji, imageUrl);
                       }
                     }}
-                    onMouseEnter={(e) => handleBadgeMouseEnter(emoji, e.currentTarget)}
+                    onMouseEnter={(e) => handleBadgeMouseEnter(key, e.currentTarget)}
                     onMouseLeave={handleBadgeMouseLeave}
-                    onTouchStart={(e) => handleBadgeTouchStart(emoji, e.currentTarget)}
+                    onTouchStart={(e) => handleBadgeTouchStart(key, e.currentTarget)}
                     onTouchEnd={handleBadgeTouchEnd}
                     onTouchCancel={handleBadgeTouchEnd}
                     onTouchMove={handleBadgeTouchMove}
@@ -591,7 +590,7 @@ function ThreadNoteItem({
             }
           }}
           isAlreadyReacted={
-            !!(myPubkey && noteReactions?.get("+")?.pubkeys?.has(myPubkey))
+            !!(myPubkey && noteReactions?.get(reactionKey("👍"))?.pubkeys?.has(myPubkey))
           }
           onRepost={() => {
             // スレッド内ノートのリポストは未実装（将来対応）

--- a/apps/web/app/hooks/useNostrReactions.ts
+++ b/apps/web/app/hooks/useNostrReactions.ts
@@ -7,14 +7,7 @@ import {
   REACTION_SINCE_SAFETY_MARGIN,
 } from "../lib/constants";
 import type { NoteCard, Reactions } from "../lib/types";
-
-/** カスタム絵文字（:shortcode: 形式）のイベントタグから画像URLを取得する */
-const extractCustomEmojiUrl = (emoji: string, tags: string[][]): string | undefined => {
-  if (!emoji.startsWith(":") || !emoji.endsWith(":") || emoji.length <= 2) return undefined;
-  const shortcode = emoji.slice(1, -1);
-  const emojiTag = tags.find(tag => tag[0] === "emoji" && tag[1] === shortcode && tag[2]);
-  return emojiTag?.[2];
-};
+import { aggregateReactionEvent } from "../lib/reactions";
 
 export interface UseNostrReactionsResult {
   reactions: Reactions;
@@ -38,48 +31,13 @@ export function useNostrReactions(
   const reactionIntervalRef = useRef<number | null>(null);
   const lastReactionSubClosedAtRef = useRef<number | undefined>(undefined);
 
-  /** リアクションのcontentを正規化する */
-  const normalizeReactionContent = useCallback((content: string): string | null => {
-    if (content === "+" || content === "") return "👍";
-    if (content === "-") return "👎";
-    if (content.startsWith(":") && content.endsWith(":") && content.length > 2) return content;
-    return content;
-  }, []);
-
   /** kind:7リアクションイベントを集計に追加する */
   const addReaction = useCallback((event: Event) => {
     if (seenReactionIdsRef.current.has(event.id)) return;
     seenReactionIdsRef.current.add(event.id);
 
-    const eTags = event.tags.filter((tag) => tag[0] === "e" && tag[1]);
-    if (eTags.length === 0) return;
-    const targetEventId = eTags[eTags.length - 1]![1]!;
-
-    const emoji = normalizeReactionContent(event.content);
-    if (emoji === null) return;
-
-    const imageUrl = extractCustomEmojiUrl(emoji, event.tags);
-
-    setReactions((prev) => {
-      const next = new Map(prev);
-      const eventReactions = next.get(targetEventId);
-      if (eventReactions) {
-        const updated = new Map(eventReactions);
-        const existing = updated.get(emoji);
-        if (existing) {
-          const newPubkeys = new Set(existing.pubkeys);
-          newPubkeys.add(event.pubkey);
-          updated.set(emoji, { count: existing.count + 1, imageUrl: existing.imageUrl ?? imageUrl, pubkeys: newPubkeys });
-        } else {
-          updated.set(emoji, { count: 1, imageUrl, pubkeys: new Set([event.pubkey]) });
-        }
-        next.set(targetEventId, updated);
-      } else {
-        next.set(targetEventId, new Map([[emoji, { count: 1, imageUrl, pubkeys: new Set([event.pubkey]) }]]));
-      }
-      return next;
-    });
-  }, [normalizeReactionContent]);
+    setReactions((prev) => aggregateReactionEvent(prev, event));
+  }, []);
 
   // kind:7 subscribe（initialEventIdsが空でなくなったら開始）
   useEffect(() => {
@@ -107,30 +65,11 @@ export function useNostrReactions(
           reactionInitialLoading = false;
           // バッファを一括でstateに反映
           if (reactionBuffer.length > 0) {
-            const batchReactions: Reactions = new Map();
+            let batchReactions: Reactions = new Map();
             for (const evt of reactionBuffer) {
               if (seenReactionIdsRef.current.has(evt.id)) continue;
               seenReactionIdsRef.current.add(evt.id);
-              const eTags = evt.tags.filter((tag) => tag[0] === "e" && tag[1]);
-              if (eTags.length === 0) continue;
-              const targetId = eTags[eTags.length - 1]![1]!;
-              const emoji = normalizeReactionContent(evt.content);
-              if (emoji === null) continue;
-
-              const imageUrl = extractCustomEmojiUrl(emoji, evt.tags);
-
-              const eventReactions = batchReactions.get(targetId);
-              if (eventReactions) {
-                const existing = eventReactions.get(emoji);
-                if (existing) {
-                  existing.pubkeys.add(evt.pubkey);
-                  eventReactions.set(emoji, { count: existing.count + 1, imageUrl: existing.imageUrl ?? imageUrl, pubkeys: existing.pubkeys });
-                } else {
-                  eventReactions.set(emoji, { count: 1, imageUrl, pubkeys: new Set([evt.pubkey]) });
-                }
-              } else {
-                batchReactions.set(targetId, new Map([[emoji, { count: 1, imageUrl, pubkeys: new Set([evt.pubkey]) }]]));
-              }
+              batchReactions = aggregateReactionEvent(batchReactions, evt);
             }
             setReactions(batchReactions);
           }
@@ -202,7 +141,7 @@ export function useNostrReactions(
       seenReactionIdsRef.current.clear();
       setReactions(new Map());
     };
-  }, [pool, relayUrls, initialEventIds, addReaction, normalizeReactionContent, notesRef, newNotesMinCreatedAtRef]);
+  }, [pool, relayUrls, initialEventIds, addReaction, notesRef, newNotesMinCreatedAtRef]);
 
   return { reactions, addReaction };
 }

--- a/apps/web/app/lib/__tests__/reactions.test.ts
+++ b/apps/web/app/lib/__tests__/reactions.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { Event } from "nostr-tools/core";
+import { aggregateReactionEvent, reactionKey } from "../reactions";
+import type { Reactions } from "../types";
+
+function event(id: string, pubkey: string, content: string, tags: string[][]): Event {
+  return { id, pubkey, content, tags, kind: 7, created_at: 1, sig: "sig" };
+}
+
+function aggregate(...events: Event[]): Reactions {
+  return events.reduce(aggregateReactionEvent, new Map() as Reactions);
+}
+
+describe("reaction aggregation", () => {
+  it("同じshortcodeでも画像URLが異なるカスタム絵文字は別集計にする", () => {
+    const reactions = aggregate(
+      event("1", "alice", ":party:", [["e", "note"], ["emoji", "party", "https://a.example/party.png"]]),
+      event("2", "bob", ":party:", [["e", "note"], ["emoji", "party", "https://b.example/party.png"]]),
+    ).get("note")!;
+
+    expect(reactions).toHaveLength(2);
+    expect(reactions.get(reactionKey(":party:", "https://a.example/party.png"))).toMatchObject({
+      emoji: ":party:", count: 1, imageUrl: "https://a.example/party.png",
+    });
+    expect(reactions.get(reactionKey(":party:", "https://b.example/party.png"))).toMatchObject({
+      emoji: ":party:", count: 1, imageUrl: "https://b.example/party.png",
+    });
+  });
+
+  it("shortcodeと画像URLが同じカスタム絵文字だけをまとめる", () => {
+    const reactions = aggregate(
+      event("1", "alice", ":party:", [["e", "note"], ["emoji", "party", "https://example.com/party.png"]]),
+      event("2", "bob", ":party:", [["e", "note"], ["emoji", "party", "https://example.com/party.png"]]),
+    ).get("note")!;
+
+    const summary = reactions.get(reactionKey(":party:", "https://example.com/party.png"));
+    expect(reactions).toHaveLength(1);
+    expect(summary?.count).toBe(2);
+    expect(summary?.pubkeys).toEqual(new Set(["alice", "bob"]));
+  });
+
+  it("通常絵文字と正規化された + は従来どおり絵文字単位でまとめる", () => {
+    const reactions = aggregate(
+      event("1", "alice", "+", [["e", "note"]]),
+      event("2", "bob", "👍", [["e", "note"], ["emoji", "irrelevant", "https://example.com/x.png"]]),
+    ).get("note")!;
+
+    expect(reactions).toHaveLength(1);
+    expect(reactions.get(reactionKey("👍"))?.count).toBe(2);
+  });
+
+  it("複合キーの境界が曖昧にならず衝突しない", () => {
+    expect(reactionKey(":a:", "b|c")).not.toBe(reactionKey(":a:", "b",));
+    expect(reactionKey(":a:", "b|c")).not.toBe(reactionKey("b|c"));
+  });
+});

--- a/apps/web/app/lib/reactions.ts
+++ b/apps/web/app/lib/reactions.ts
@@ -1,0 +1,49 @@
+import type { Event } from "nostr-tools/core";
+import type { Reactions } from "./types";
+
+export function normalizeReactionContent(content: string): string {
+  if (content === "+" || content === "") return "👍";
+  if (content === "-") return "👎";
+  return content;
+}
+
+function isCustomEmoji(emoji: string): boolean {
+  return emoji.startsWith(":") && emoji.endsWith(":") && emoji.length > 2;
+}
+
+export function extractCustomEmojiUrl(emoji: string, tags: string[][]): string | undefined {
+  if (!isCustomEmoji(emoji)) return undefined;
+  const shortcode = emoji.slice(1, -1);
+  return tags.find((tag) => tag[0] === "emoji" && tag[1] === shortcode && tag[2])?.[2];
+}
+
+/** JSON tuple prevents collisions between Unicode and custom emoji key components. */
+export function reactionKey(emoji: string, imageUrl?: string): string {
+  return isCustomEmoji(emoji)
+    ? JSON.stringify(["custom", emoji, imageUrl ?? null])
+    : JSON.stringify(["unicode", emoji]);
+}
+
+/** Add one event without mutating the previous aggregation. */
+export function aggregateReactionEvent(reactions: Reactions, event: Event): Reactions {
+  const eTags = event.tags.filter((tag) => tag[0] === "e" && tag[1]);
+  if (eTags.length === 0) return reactions;
+
+  const targetEventId = eTags[eTags.length - 1]![1]!;
+  const emoji = normalizeReactionContent(event.content);
+  const imageUrl = extractCustomEmojiUrl(emoji, event.tags);
+  const key = reactionKey(emoji, imageUrl);
+  const next = new Map(reactions);
+  const eventReactions = new Map(next.get(targetEventId));
+  const existing = eventReactions.get(key);
+
+  if (existing) {
+    const pubkeys = new Set(existing.pubkeys);
+    pubkeys.add(event.pubkey);
+    eventReactions.set(key, { ...existing, count: existing.count + 1, pubkeys });
+  } else {
+    eventReactions.set(key, { emoji, count: 1, imageUrl, pubkeys: new Set([event.pubkey]) });
+  }
+  next.set(targetEventId, eventReactions);
+  return next;
+}

--- a/apps/web/app/lib/types.ts
+++ b/apps/web/app/lib/types.ts
@@ -57,8 +57,15 @@ export interface ThreadCard extends CardBase {
 /** キャンバス上に配置されるカード（Discriminated Union） */
 export type Card = NoteCard | ComposeCard | ThreadCard;
 
-/** リアクション集計: eventId → (絵文字 → {件数, 画像URL, 送信者pubkey集合}) のマッピング */
-export type Reactions = Map<string, Map<string, { count: number; imageUrl?: string; pubkeys: Set<string> }>>;
+export interface ReactionSummary {
+  emoji: string;
+  count: number;
+  imageUrl?: string;
+  pubkeys: Set<string>;
+}
+
+/** リアクション集計: eventId → (リアクション複合キー → 集計値) のマッピング */
+export type Reactions = Map<string, Map<string, ReactionSummary>>;
 
 /** プロフィール情報 */
 export interface NostrProfile {


### PR DESCRIPTION
## 変更内容

- カスタム絵文字リアクションを shortcode と画像URLの組み合わせで集計
- 同じshortcodeでも画像URLが異なる場合は別バッジとして表示
- Unicode絵文字は従来どおり絵文字単位で集計
- 初期ロードと差分追加の集計処理を共通化
- バッジ表示、ツールチップ、既リアクション判定を複合キーへ対応

## 背景

従来はカスタム絵文字をshortcodeだけで集計していたため、同じshortcodeに異なる画像URLが指定されたリアクションが一つのバッジへ統合されていました。

## 影響

カスタム絵文字の画像ごとの反応数とリアクションしたユーザーを正しく確認できます。通常のUnicode絵文字の表示・集計方法は変わりません。

## 検証

- 全テスト: 105件成功
- 新規リアクション集計テスト: 4件成功
- Next.js production build・型チェック: 成功
- ESLint: エラー0（既存警告24件）
- `npx tsc --noEmit`: 既存の `layoutEngine.test.ts` におけるVitestグローバル型不足で失敗

## 残課題

- 本変更に起因する残課題なし
