### PR TITLE
relayのRust toolchainを1.97.1に固定

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -15,6 +15,8 @@ jobs:
         working-directory: services/relay
     steps:
       - uses: actions/checkout@v4
+      - name: muslビルドツールをインストール
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: services/relay
@@ -24,3 +26,5 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: テスト
         run: cargo test
+      - name: 本番バイナリビルド
+        run: cargo build --release --target aarch64-unknown-linux-musl --features dynamo

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -15,9 +15,6 @@ jobs:
         working-directory: services/relay
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: services/relay

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,6 @@ jobs:
       - name: Install musl-tools
         run: sudo apt-get update && sudo apt-get install -y musl-tools
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-unknown-linux-musl
-
       - name: Setup Cargo cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Client --> CloudFront (SSL) --> EC2 (t4g.micro, port 3000)
 
 ### Rust コーディング規約
 
+- Rust toolchain は `services/relay/rust-toolchain.toml` で固定する。ローカル開発・CI・本番バイナリのビルドはこの定義を共通で使用すること
 - **モジュール構成**: `store/mod.rs` 方式ではなく `store.rs` + `store/` ディレクトリ方式を使うこと（Rust 2018+ スタイル）
   - ✅ `src/store.rs` + `src/store/in_memory.rs` + `src/store/dynamo.rs`
   - ❌ `src/store/mod.rs` + `src/store/in_memory.rs` + `src/store/dynamo.rs`
@@ -53,15 +54,14 @@ Client --> CloudFront (SSL) --> EC2 (t4g.micro, port 3000)
 ### リレーサーバー (ARM64 for EC2)
 
 ```bash
-# ローカルビルド（Mac → Linux ARM64 クロスコンパイル）
+# `rust-toolchain.toml` の固定バージョンが自動で選択される
 cd services/relay
-ulimit -n 10240  # macOSのFD制限回避
-cargo zigbuild --release --target aarch64-unknown-linux-gnu --features dynamo -j 1
+cargo build --release --target aarch64-unknown-linux-musl --features dynamo
 
 # デプロイ（S3経由 + SSM Document）
 # バイナリのアップロード
 aws-vault exec nostr-relay -- aws s3 cp \
-  target/aarch64-unknown-linux-gnu/release/relay \
+  target/aarch64-unknown-linux-musl/release/relay \
   s3://nostr-relay-binary-426192960050/relay-v2/relay
 
 # envファイルのアップロード（deploy/relay-v2.env をgitで管理）
@@ -76,6 +76,7 @@ aws-vault exec nostr-relay -- aws ssm send-command \
 ```
 
 > **Note:** 環境変数は `deploy/relay-v2.env` でgit管理されています。変更はこのファイルを編集し、S3にアップロード後、SSM Documentを実行してください。
+> 本番EC2にはRust toolchainをインストールせず、CIでビルドしたバイナリのみを配布します。
 
 ### Webフロントエンド
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,11 @@ Client --> CloudFront (SSL) --> EC2 (t4g.micro, port 3000)
 ### リレーサーバー (ARM64 for EC2)
 
 ```bash
-# `rust-toolchain.toml` の固定バージョンが自動で選択される
+# macOSからLinux ARM64向けにクロスコンパイル
+# 事前にcargo-zigbuildとZigをインストールすること
 cd services/relay
-cargo build --release --target aarch64-unknown-linux-musl --features dynamo
+ulimit -n 10240  # macOSのFD制限回避
+cargo zigbuild --release --target aarch64-unknown-linux-musl --features dynamo -j 1
 
 # デプロイ（S3経由 + SSM Document）
 # バイナリのアップロード

--- a/services/relay/Cargo.toml
+++ b/services/relay/Cargo.toml
@@ -2,6 +2,7 @@
 name = "relay"
 version = "2.0.0"
 edition = "2024"
+rust-version = "1.97.1"
 
 # ARM64向けバイナリ設定
 [[bin]]

--- a/services/relay/rust-toolchain.toml
+++ b/services/relay/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.97.1"
+profile = "minimal"
+components = ["rustfmt", "clippy"]
+targets = ["aarch64-unknown-linux-musl"]


### PR DESCRIPTION
## 概要

リレーサーバーで使用する Rust toolchain を 1.97.1 に固定します。

## 変更内容

- `services/relay/rust-toolchain.toml` を追加
  - Rust 1.97.1
  - rustfmt / clippy
  - aarch64-unknown-linux-musl target
- `Cargo.toml` に `rust-version = "1.97.1"` を明記
- CI・deploy workflow の `stable` 指定を削除し、`rust-toolchain.toml` を単一の基準として使用
- PR CI に本番相当の aarch64-unknown-linux-musl release build を追加
- `CLAUDE.md` の macOS 向けクロスビルド手順を `cargo zigbuild` と必要ツールが分かる内容に更新
- 本番 EC2 には Rust をインストールせず、CI で生成したバイナリを配布する現行構成を維持

## 検証

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`（216 tests）
- [x] `cargo build --release --features dynamo`
- [x] `cargo metadata --locked`
- [x] `git diff --check`
- [x] `cargo build --release --target aarch64-unknown-linux-musl --features dynamo`
  - PR CI の ARM64 ランナーで `musl-tools` を導入し、本番相当ビルドに成功
