### PR TITLE
RelayのCargo依存関係を更新

### DIFF
--- a/services/relay/Cargo.lock
+++ b/services/relay/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.119.0"
+version = "1.120.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0176c1927f2e065f43cecde84602f769959b34ab53a317da92a64022ba09345"
+checksum = "f578638cafe182113da770e9798e7063d6de96cbbfe06f647d0026f197c9b97c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -168,6 +168,7 @@ dependencies = [
  "http 1.5.0",
  "regex-lite",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -845,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deranged"
@@ -1256,9 +1257,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1523,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itoa"
@@ -1824,7 +1825,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -1975,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2158,7 +2159,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2650,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",


### PR DESCRIPTION
## 概要

`services/relay/Cargo.lock`のみを更新し、現在のmanifest制約内で利用可能なpatch/minor更新を適用しました。`Cargo.toml`は変更していません。

## 更新対象

- direct: `aws-sdk-dynamodb` 1.119.0 → 1.120.0（minor）
- transitive: `aho-corasick` 1.1.4 → 1.1.5（patch）
- transitive: `android_system_properties` 0.1.5 → 0.1.6（patch）
- transitive: `data-encoding` 2.11.0 → 2.11.1（patch）
- transitive: `hybrid-array` 0.4.13 → 0.4.14（patch）
- transitive: `ipnet` 2.12.0 → 2.12.1（patch）
- transitive: `regex-automata` 0.4.16 → 0.4.18（patch）
- transitive: `time` 0.3.54 → 0.3.55（patch）

lock再解決に伴い、更新crate内部のtarget別依存参照（`socket2`、`windows-sys`）も既存lock内の新しい同居版へ切り替わっています。

## 検証

- `cargo clippy --all-targets --all-features -- -D warnings`: 成功
- `cargo test`: 成功（unit 182、E2E 30、NIP-11 4、合計216件、失敗0）
- `cargo test`のdefault featureビルドでは既存の`src/main.rs`の未使用import警告が1件出ますが、テスト結果は成功です。今回のlock差分による新規回帰ではなく、all-featuresの必須clippyは警告ゼロで成功しています。

## 未適用候補と評価

- `secp256k1` 0.31.1 → 0.32.0-beta.2: 現在の`0.31`制約外かつpre-release majorのため未適用。manifest変更とAPI移行確認が必要です。MSRV 1.63で現行1.97.1には収まりますが、署名・検証はRelayプロトコルの中核なので、安定版公開後に破壊的変更、BIP340署名互換、serde表現を重点確認し、単独PRで扱うのを推奨します。永続化形式への直接影響は想定しにくいものの、イベント検証結果への影響は高リスクです。ARM64では`secp256k1-sys`のネイティブビルド確認も必要です。
- `generic-array` 0.14.7 → 0.14.9: `digest 0.10`系（`sha1`経由）の依存制約下でlockfileのみでは更新不可。direct manifest変更で無理に固定せず、親依存更新時に追随を推奨します。
- `matchit` 0.8.4 → 0.8.6（latest 0.9.2）: `axum 0.8.9`の依存制約下でlockfileのみでは更新不可。axum自体は安定最新版のため、上流更新待ちを推奨します。Relay routingへの影響があるため強制overrideは避けます。
- AWS TLS経路: 追加確認の`cargo audit`で既存の`rustls-webpki 0.101.7`にRUSTSEC-2026-0098/0099/0104を検出しました。依存経路は`aws-config/aws-sdk-dynamodb → aws-smithy-runtime → aws-smithy-http-client → rustls 0.21.12 → rustls-webpki 0.101.7`で、更新前lockにも同版が存在します。修正版は0.103.12/0.103.13系ですが互換制約外のため、lockfileだけでは解消できません。AWS SDKのTLS feature/上流修正を調査し、DynamoDB接続・証明書検証・ARM64本番ビルドを確認する単独PRを推奨します。永続化スキーマやRelay wire protocolへの直接変更はありませんが、TLS証明書/CRL処理にセキュリティ影響があります。

`tokio`、`axum`、`serde`、`tracing`、`aws-config`を含むその他direct依存は安定最新版で、追加のmanifest更新候補はありません。